### PR TITLE
fix(naming-spec): all POMs for specific sub projects contain the modu…

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -4,10 +4,10 @@
 
 	<modelVersion>4.0.0</modelVersion>
 	<groupId>de.evoila.cf.broker</groupId>
-	<artifactId>parent</artifactId>
+	<artifactId>core-parent</artifactId>
 	<version>1.1.0</version>
 	<packaging>pom</packaging>
-	<name>parent</name>
+	<name>core-parent</name>
 
 	<parent>
 		<groupId>org.springframework.boot</groupId>
@@ -20,7 +20,6 @@
 		<module>core</module>
 		<module>model</module>
 		<module>custom-parent</module>
-		
 	</modules>
 
 	<properties>


### PR DESCRIPTION
…le prefix in the POM. Only core does not, so it looks quite ugly in Eclipse