### PR TITLE
chore: Cleanup model classes.

### DIFF
--- a/model/src/main/java/de/evoila/cf/broker/exception/InvalidParametersException.java
+++ b/model/src/main/java/de/evoila/cf/broker/exception/InvalidParametersException.java
@@ -3,7 +3,8 @@ package de.evoila.cf.broker.exception;
 import java.util.Map;
 
 public class InvalidParametersException extends Exception{
-    private static final long serialVersionUID = 2L;
+
+    private static final long serialVersionUID = 858570104362828780L;
 
     private Map<String, Object> parameters;
 
@@ -18,11 +19,10 @@ public class InvalidParametersException extends Exception{
     }
 
     @Override
-    public String getMessage()
-    {
+    public String getMessage() {
         if (errorMessage == null){
             return "The specified parameters are invalid";
-        }else{
+        } else {
             return this.errorMessage;
         }
     }

--- a/model/src/main/java/de/evoila/cf/broker/exception/PlatformException.java
+++ b/model/src/main/java/de/evoila/cf/broker/exception/PlatformException.java
@@ -9,10 +9,7 @@ package de.evoila.cf.broker.exception;
  */
 public class PlatformException extends Exception {
 
-	/**
-	 * 
-	 */
-	private static final long serialVersionUID = 1L;
+	private static final long serialVersionUID = 8072466984852751167L;
 	
 	public PlatformException(String message) {
 		super(message);

--- a/model/src/main/java/de/evoila/cf/broker/exception/ServiceBrokerException.java
+++ b/model/src/main/java/de/evoila/cf/broker/exception/ServiceBrokerException.java
@@ -10,6 +10,7 @@ package de.evoila.cf.broker.exception;
 public class ServiceBrokerException extends Exception {
 
 	private static final long serialVersionUID = -5544859893499349135L;
+
 	private String message;
 
 	public ServiceBrokerException() { }

--- a/model/src/main/java/de/evoila/cf/broker/exception/ServiceDefinitionDoesNotExistException.java
+++ b/model/src/main/java/de/evoila/cf/broker/exception/ServiceDefinitionDoesNotExistException.java
@@ -9,6 +9,7 @@ package de.evoila.cf.broker.exception;
 public class ServiceDefinitionDoesNotExistException extends Exception {
 	
 	private static final long serialVersionUID = -62090827040416788L;
+
 	private String serviceDefinitionId;
 	
 	public ServiceDefinitionDoesNotExistException(String serviceDefinitionId) {

--- a/model/src/main/java/de/evoila/cf/broker/exception/ServiceInstanceBindingDoesNotExistsException.java
+++ b/model/src/main/java/de/evoila/cf/broker/exception/ServiceInstanceBindingDoesNotExistsException.java
@@ -8,6 +8,7 @@ package de.evoila.cf.broker.exception;
  *
  */
 public class ServiceInstanceBindingDoesNotExistsException extends Exception {
+
 	private static final long serialVersionUID = -1879753092397657116L;
 
 	private String bindingId;

--- a/model/src/main/java/de/evoila/cf/broker/exception/ServiceInstanceBindingException.java
+++ b/model/src/main/java/de/evoila/cf/broker/exception/ServiceInstanceBindingException.java
@@ -7,10 +7,10 @@ import org.springframework.http.HttpStatus;
  */
 public class ServiceInstanceBindingException extends Exception {
 
-    String instanceId;
-    String bindingId;
-    HttpStatus httpStatus;
-    String errorMessage;
+    private String instanceId;
+    private String bindingId;
+    private HttpStatus httpStatus;
+    private String errorMessage;
 
     public ServiceInstanceBindingException(String instanceId, String bindingId,
                                            HttpStatus httpStatus, String errorMessage) {

--- a/model/src/main/java/de/evoila/cf/broker/model/BindResource.java
+++ b/model/src/main/java/de/evoila/cf/broker/model/BindResource.java
@@ -3,7 +3,8 @@ package de.evoila.cf.broker.model;
 import com.fasterxml.jackson.annotation.JsonAutoDetect;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.databind.annotation.JsonSerialize;
-import org.hibernate.validator.constraints.NotEmpty;
+
+import javax.validation.constraints.NotEmpty;
 
 @JsonAutoDetect(getterVisibility = JsonAutoDetect.Visibility.NONE)
 public class BindResource {

--- a/model/src/main/java/de/evoila/cf/broker/model/BoshProperties.java
+++ b/model/src/main/java/de/evoila/cf/broker/model/BoshProperties.java
@@ -1,9 +1,46 @@
 package de.evoila.cf.broker.model;
 
+import java.util.LinkedList;
 import java.util.List;
 
 public class BoshProperties {
-    int instanceNumber;
-    List<String> createErrands;
-    List<String> updateErrands;
+
+    private int instanceNumber;
+    private List<String> createErrands;
+    private List<String> updateErrands;
+
+    public BoshProperties() {
+        createErrands = new LinkedList<>();
+        updateErrands = new LinkedList<>();
+    }
+
+    public BoshProperties(int instanceNumber, List<String> createErrands, List<String> updateErrands) {
+        this.instanceNumber = instanceNumber;
+        this.createErrands = createErrands;
+        this.updateErrands = updateErrands;
+    }
+
+    public int getInstanceNumber() {
+        return instanceNumber;
+    }
+
+    public void setInstanceNumber(int instanceNumber) {
+        this.instanceNumber = instanceNumber;
+    }
+
+    public List<String> getCreateErrands() {
+        return createErrands;
+    }
+
+    public void setCreateErrands(List<String> createErrands) {
+        this.createErrands = createErrands;
+    }
+
+    public List<String> getUpdateErrands() {
+        return updateErrands;
+    }
+
+    public void setUpdateErrands(List<String> updateErrands) {
+        this.updateErrands = updateErrands;
+    }
 }

--- a/model/src/main/java/de/evoila/cf/broker/model/DashboardClient.java
+++ b/model/src/main/java/de/evoila/cf/broker/model/DashboardClient.java
@@ -19,7 +19,12 @@ public class DashboardClient {
 	private String redirectUri;
 	
 	public DashboardClient() {
-		super();
+	}
+
+	public DashboardClient(String id, String secret, String redirectUri) {
+		this.id = id;
+		this.secret = secret;
+		this.redirectUri = redirectUri;
 	}
 
 	public String getId() {

--- a/model/src/main/java/de/evoila/cf/broker/model/HABackendResponse.java
+++ b/model/src/main/java/de/evoila/cf/broker/model/HABackendResponse.java
@@ -8,27 +8,20 @@ package de.evoila.cf.broker.model;
  *
  */
 public class HABackendResponse {
+
 	private String ip;
-
 	private int port;
-
 	private String identifier;
 
-	/**
-	 * @param ip
-	 * @param port
-	 * @param identifier
-	 */
+	public HABackendResponse() {
+	}
+
 	public HABackendResponse(String ip, int port, String identifier) {
 		this.ip = ip;
 		this.port = port;
 		this.identifier = identifier;		
 	}
 	
-	public HABackendResponse() {
-		
-	}
-
 	public String getIp() {
 		return ip;
 	}

--- a/model/src/main/java/de/evoila/cf/broker/model/HAProxyServerAddress.java
+++ b/model/src/main/java/de/evoila/cf/broker/model/HAProxyServerAddress.java
@@ -21,20 +21,6 @@ public class HAProxyServerAddress extends ServerAddress {
 		super();
 	}
 
-	public HAProxyServerAddress(ServerAddress serverAddress, Mode mode, List<String> options) {
-		super(serverAddress);
-		this.mode = mode.toString();
-		this.options= options;
-	}
-
-	public HAProxyServerAddress(HAProxyServerAddress haProxyServerAddress, String name) {
-		this.setIp(haProxyServerAddress.getIp());
-		this.setPort(haProxyServerAddress.getPort());
-		this.setName(name);
-		this.setMode(haProxyServerAddress.getMode());
-		this.setOptions(haProxyServerAddress.getOptions());
-	}
-
 	public HAProxyServerAddress(String name) {
 		super(name);
 	}
@@ -50,6 +36,20 @@ public class HAProxyServerAddress extends ServerAddress {
 	public HAProxyServerAddress(String name, String ip, int port, String mode) {
 		super(name, ip, port);
 		this.mode = mode;
+	}
+
+	public HAProxyServerAddress(ServerAddress serverAddress, Mode mode, List<String> options) {
+		super(serverAddress);
+		this.mode = mode.toString();
+		this.options= options;
+	}
+
+	public HAProxyServerAddress(HAProxyServerAddress haProxyServerAddress, String name) {
+		this.setIp(haProxyServerAddress.getIp());
+		this.setPort(haProxyServerAddress.getPort());
+		this.setName(name);
+		this.setMode(haProxyServerAddress.getMode());
+		this.setOptions(haProxyServerAddress.getOptions());
 	}
 
 	public String getMode() {

--- a/model/src/main/java/de/evoila/cf/broker/model/JobProgress.java
+++ b/model/src/main/java/de/evoila/cf/broker/model/JobProgress.java
@@ -42,24 +42,18 @@ public class JobProgress implements BaseEntity<String> {
 	private String operation;
 
 	public JobProgress() {
-		super();
+	}
+
+	public JobProgress(String serviceInstanceId, String progress, String description) {
+		this(serviceInstanceId, progress, description, null);
 	}
 
 	public JobProgress(String serviceInstanceId, String progress, String description, String operation) {
-		super();
 		this.id = serviceInstanceId;
 		this.state = progress;
 		this.date = new Date();
 		this.description = description;
 		this.operation = operation;
-	}
-
-	public JobProgress(String serviceInstanceId, String progress, String description) {
-		super();
-		this.id = serviceInstanceId;
-		this.state = progress;
-		this.date = new Date();
-		this.description = description;
 	}
 
 	@Override

--- a/model/src/main/java/de/evoila/cf/broker/model/JobProgressResponse.java
+++ b/model/src/main/java/de/evoila/cf/broker/model/JobProgressResponse.java
@@ -16,7 +16,7 @@ import com.fasterxml.jackson.databind.annotation.JsonSerialize;
 public class JobProgressResponse {
 
 	/**
-	 * Allowed values are: "in progress" "succeeded" "failed"
+	 * Allowed values are: "in progress", "succeeded", "failed"
 	 */
 	@JsonSerialize
 	@JsonProperty("state")
@@ -27,17 +27,13 @@ public class JobProgressResponse {
 	private String description;
 
 	public JobProgressResponse() {
-		super();
 	}
 	
 	public JobProgressResponse(JobProgress jobProgress) {
-		super();
-		this.state = jobProgress.getState();
-		this.description = jobProgress.getDescription();
+		this(jobProgress.getState(), jobProgress.getDescription());
 	}
 
 	public JobProgressResponse(String state, String description) {
-		super();
 		this.state = state;
 		this.description = description;
 	}

--- a/model/src/main/java/de/evoila/cf/broker/model/Server.java
+++ b/model/src/main/java/de/evoila/cf/broker/model/Server.java
@@ -9,6 +9,14 @@ public class Server {
 
     private String identifier;
 
+    public Server() {
+    }
+
+    public Server(String url, String identifier) {
+        this.url = url;
+        this.identifier = identifier;
+    }
+
     public String getUrl() {
         return url;
     }

--- a/model/src/main/java/de/evoila/cf/broker/model/ServiceInstanceBinding.java
+++ b/model/src/main/java/de/evoila/cf/broker/model/ServiceInstanceBinding.java
@@ -32,13 +32,10 @@ public class ServiceInstanceBinding implements BaseEntity<String> {
 	private List<VolumeMount> volumeMounts;
 
 	public ServiceInstanceBinding() {
-		super();
 	}
 
     public ServiceInstanceBinding(String id, String serviceInstanceId, Map<String, Object> credentials) {
-        this.id = id;
-        this.serviceInstanceId = serviceInstanceId;
-        setCredentials(credentials);
+		this(id, serviceInstanceId, credentials, null);
     }
 
 	public ServiceInstanceBinding(String id, String serviceInstanceId, Map<String, Object> credentials,

--- a/model/src/main/java/de/evoila/cf/broker/model/ServiceInstanceBindingRequest.java
+++ b/model/src/main/java/de/evoila/cf/broker/model/ServiceInstanceBindingRequest.java
@@ -4,8 +4,8 @@ import com.fasterxml.jackson.annotation.JsonAutoDetect;
 import com.fasterxml.jackson.annotation.JsonAutoDetect.Visibility;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.databind.annotation.JsonSerialize;
-import org.hibernate.validator.constraints.NotEmpty;
 
+import javax.validation.constraints.NotEmpty;
 import java.util.Map;
 
 /**

--- a/model/src/main/java/de/evoila/cf/broker/model/ServiceInstanceCreationResult.java
+++ b/model/src/main/java/de/evoila/cf/broker/model/ServiceInstanceCreationResult.java
@@ -9,59 +9,30 @@ package de.evoila.cf.broker.model;
  */
 public class ServiceInstanceCreationResult {
 
-	/**
-	 * 
-	 */
 	private String internalId;
 
-	/**
-	 * 
-	 */
 	private String daschboardUrl;
 
-	/**
-	 * 
-	 */
 	public ServiceInstanceCreationResult() {
-		super();
 	}
 
-	/**
-	 * @param internalId
-	 * @param daschboardUrl
-	 */
 	public ServiceInstanceCreationResult(String internalId, String daschboardUrl) {
-		super();
 		this.internalId = internalId;
 		this.daschboardUrl = daschboardUrl;
 	}
 
-	/**
-	 * @return the internalId
-	 */
 	public String getInternalId() {
 		return internalId;
 	}
 
-	/**
-	 * @param internalId
-	 *            the internalId to set
-	 */
 	public void setInternalId(String internalId) {
 		this.internalId = internalId;
 	}
 
-	/**
-	 * @return the daschboardUrl
-	 */
 	public String getDaschboardUrl() {
 		return daschboardUrl;
 	}
 
-	/**
-	 * @param daschboardUrl
-	 *            the daschboardUrl to set
-	 */
 	public void setDaschboardUrl(String daschboardUrl) {
 		this.daschboardUrl = daschboardUrl;
 	}

--- a/model/src/main/java/de/evoila/cf/broker/model/ServiceInstanceRequest.java
+++ b/model/src/main/java/de/evoila/cf/broker/model/ServiceInstanceRequest.java
@@ -4,8 +4,8 @@ import com.fasterxml.jackson.annotation.JsonAutoDetect;
 import com.fasterxml.jackson.annotation.JsonAutoDetect.Visibility;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.databind.annotation.JsonSerialize;
-import org.hibernate.validator.constraints.NotEmpty;
 
+import javax.validation.constraints.NotEmpty;
 import java.util.HashMap;
 import java.util.Map;
 

--- a/model/src/main/java/de/evoila/cf/broker/model/backup/EndpointCredential.java
+++ b/model/src/main/java/de/evoila/cf/broker/model/backup/EndpointCredential.java
@@ -4,17 +4,29 @@ import de.evoila.cf.broker.model.backup.enums.BackupType;
 
 public class EndpointCredential {
 
-    String serviceInstanceId;
+    private String serviceInstanceId;
 
-    String hostname;
+    private String hostname;
 
-    int port;
+    private int port;
 
-    String username;
+    private String username;
 
-    String password;
+    private String password;
 
-    BackupType type;
+    private BackupType type;
+
+    public EndpointCredential() {
+    }
+
+    public EndpointCredential(String serviceInstanceId, String hostname, int port, String username, String password, BackupType type) {
+        this.serviceInstanceId = serviceInstanceId;
+        this.hostname = hostname;
+        this.port = port;
+        this.username = username;
+        this.password = password;
+        this.type = type;
+    }
 
     public String getServiceInstanceId() {
         return serviceInstanceId;

--- a/model/src/main/java/de/evoila/cf/broker/model/catalog/Dashboard.java
+++ b/model/src/main/java/de/evoila/cf/broker/model/catalog/Dashboard.java
@@ -1,5 +1,5 @@
 /**
- * 
+ *
  */
 package de.evoila.cf.broker.model.catalog;
 
@@ -10,26 +10,34 @@ import com.fasterxml.jackson.annotation.JsonProperty;
  */
 public class Dashboard {
 
-	@JsonProperty("url")
-	private String url;
-	
-	@JsonProperty("auth_endpoint")
-	private String authEndpoint;
+    @JsonProperty("url")
+    private String url;
 
-	public String getUrl() {
-		return url;
-	}
+    @JsonProperty("auth_endpoint")
+    private String authEndpoint;
 
-	public void setUrl(String url) {
-		this.url = url;
-	}
+    public Dashboard() {
+    }
 
-	public String getAuthEndpoint() {
-		return authEndpoint;
-	}
+    public Dashboard(String url, String authEndpoint) {
+        this.url = url;
+        this.authEndpoint = authEndpoint;
+    }
 
-	public void setAuthEndpoint(String authEndpoint) {
-		this.authEndpoint = authEndpoint;
-	}
-	
+    public String getUrl() {
+        return url;
+    }
+
+    public void setUrl(String url) {
+        this.url = url;
+    }
+
+    public String getAuthEndpoint() {
+        return authEndpoint;
+    }
+
+    public void setAuthEndpoint(String authEndpoint) {
+        this.authEndpoint = authEndpoint;
+    }
+
 }

--- a/model/src/main/java/de/evoila/cf/broker/model/catalog/ServerAddress.java
+++ b/model/src/main/java/de/evoila/cf/broker/model/catalog/ServerAddress.java
@@ -17,29 +17,21 @@ public class ServerAddress {
 	private boolean backup;
 
 	public ServerAddress() {
-		super();
 	}
 
 	public ServerAddress(String name) {
-		super();
-		this.name = name;
+		this(name, null);
 	}
 
 	public ServerAddress(String name, String ip) {
-		super();
-		this.name = name;
-		this.ip = ip;
+		this(name, ip, 0);
 	}
 
 	public ServerAddress(String name, String ip, int port) {
-		super();
-		this.name = name;
-		this.ip = ip;
-		this.port = port;
+		this(name, ip, port, false);
 	}
 
 	public ServerAddress(String name, String ip, int port, boolean backup) {
-        super();
         this.name = name;
         this.ip = ip;
         this.port = port;
@@ -47,10 +39,7 @@ public class ServerAddress {
     }
 
 	public ServerAddress(ServerAddress address) {
-		super();
-		this.name = address.name;
-		this.ip = address.ip;
-		this.port = address.port;
+	    this(address.getName(), address.getIp(), address.getPort());
 	}
 
     public String getName() {

--- a/model/src/main/java/de/evoila/cf/broker/model/catalog/ServiceDefinition.java
+++ b/model/src/main/java/de/evoila/cf/broker/model/catalog/ServiceDefinition.java
@@ -49,7 +49,6 @@ public class ServiceDefinition {
 	private boolean updateable;
 
 	public ServiceDefinition() {
-		super();
 	}
 
 	public ServiceDefinition(String id, String name, String description, boolean bindable, List<Plan> plans, boolean updatable) {

--- a/model/src/main/java/de/evoila/cf/broker/model/catalog/ServiceMetadata.java
+++ b/model/src/main/java/de/evoila/cf/broker/model/catalog/ServiceMetadata.java
@@ -22,6 +22,18 @@ public class ServiceMetadata {
     @JsonProperty("supportUrl")
     private String supportUrl;
 
+    public ServiceMetadata() {
+    }
+
+    public ServiceMetadata(String displayName, String imageUrl, String longDescription, String providerDisplayName, String documentationUrl, String supportUrl) {
+        this.displayName = displayName;
+        this.imageUrl = imageUrl;
+        this.longDescription = longDescription;
+        this.providerDisplayName = providerDisplayName;
+        this.documentationUrl = documentationUrl;
+        this.supportUrl = supportUrl;
+    }
+
     public String getDisplayName() {
         return displayName;
     }

--- a/model/src/main/java/de/evoila/cf/broker/model/catalog/plan/Cost.java
+++ b/model/src/main/java/de/evoila/cf/broker/model/catalog/plan/Cost.java
@@ -5,8 +5,15 @@ import java.util.Map;
 public class Cost {
 
     private Map<String, Float> amount;
-
     private String unit;
+
+    public Cost() {
+    }
+
+    public Cost(Map<String, Float> amount, String unit) {
+        this.amount = amount;
+        this.unit = unit;
+    }
 
     public Map<String, Float> getAmount() {
         return amount;

--- a/model/src/main/java/de/evoila/cf/broker/model/catalog/plan/CustomInstanceGroupConfig.java
+++ b/model/src/main/java/de/evoila/cf/broker/model/catalog/plan/CustomInstanceGroupConfig.java
@@ -7,6 +7,13 @@ public class CustomInstanceGroupConfig extends InstanceGroupConfig {
 
     protected String name;
 
+    public CustomInstanceGroupConfig() {
+    }
+
+    public CustomInstanceGroupConfig(String name) {
+        this.name = name;
+    }
+
     public String getName() {
         return name;
     }

--- a/model/src/main/java/de/evoila/cf/broker/model/catalog/plan/InstanceGroupConfig.java
+++ b/model/src/main/java/de/evoila/cf/broker/model/catalog/plan/InstanceGroupConfig.java
@@ -19,6 +19,19 @@ public class InstanceGroupConfig {
 
     protected List<String> azs;
 
+    public InstanceGroupConfig() {
+    }
+
+    public InstanceGroupConfig(Integer connections, Integer nodes, String vmType, String persistentDiskType, Map<String, Object> properties, List<NetworkReference> networks, List<String> azs) {
+        this.connections = connections;
+        this.nodes = nodes;
+        this.vmType = vmType;
+        this.persistentDiskType = persistentDiskType;
+        this.properties = properties;
+        this.networks = networks;
+        this.azs = azs;
+    }
+
     public Integer getConnections() {
         return connections;
     }

--- a/model/src/main/java/de/evoila/cf/broker/model/catalog/plan/NetworkReference.java
+++ b/model/src/main/java/de/evoila/cf/broker/model/catalog/plan/NetworkReference.java
@@ -6,19 +6,18 @@ import com.fasterxml.jackson.annotation.JsonProperty;
 import java.util.ArrayList;
 import java.util.List;
 
-@JsonIgnoreProperties(
-      ignoreUnknown = true
-)
+@JsonIgnoreProperties(ignoreUnknown = true)
 public class NetworkReference {
 
-    String name;
+    private String name;
 
     @JsonProperty("static_ips")
-    List<String> staticIps;
+    private List<String> staticIps;
 
-    List<String> defaultNetwork;
+    private List<String> defaultNetwork;
 
-    public NetworkReference() { }
+    public NetworkReference() {
+    }
 
     public NetworkReference(String network, List<String> staticIps, List<String> defaultNetwork) {
         this.name = network;
@@ -35,7 +34,7 @@ public class NetworkReference {
     }
 
     public List<String> getStaticIps() {
-        if(staticIps == null)
+        if (staticIps == null)
             staticIps = new ArrayList<>();
         return staticIps;
     }

--- a/model/src/main/java/de/evoila/cf/broker/model/catalog/plan/SchemaProperty.java
+++ b/model/src/main/java/de/evoila/cf/broker/model/catalog/plan/SchemaProperty.java
@@ -16,13 +16,13 @@ public class SchemaProperty {
 	/*
 	 * Written at the 25.05.2018 using the formal specification from
 	 * https://cswr.github.io/JsonSchema/spec/grammar/
-	 * 
-	 * Missing due to Java incompatibly - allow a List of values and a single
-	 * value for type at the same time - allow a List of items and a single
-	 * value for items at the same time - allow a Boolean and a Schema object
-	 * for additionalItems at the same time - allow a Boolean and a Schema
-	 * object for additionalProperties at the same time - dependencies in
-	 * objects
+	 *
+	 * Missing due to Java incompatibly
+	 * - allow a List of values and a single value for type at the same time
+	 * - allow a List of items and a single value for items at the same time
+	 * - allow a Boolean and a Schema object for additionalItems at the same time
+	 * - allow a Boolean and a Schema object for additionalProperties at the same time
+	 * - dependencies in objects
 	 */
 
 	@JsonSerialize

--- a/model/src/main/java/de/evoila/cf/broker/model/catalog/plan/SchemaServiceBinding.java
+++ b/model/src/main/java/de/evoila/cf/broker/model/catalog/plan/SchemaServiceBinding.java
@@ -7,6 +7,13 @@ public class SchemaServiceBinding {
 	@JsonProperty(value="create", required=false)
 	private SchemaServiceCreate create;
 
+	public SchemaServiceBinding() {
+	}
+
+	public SchemaServiceBinding(SchemaServiceCreate create) {
+		this.create = create;
+	}
+
 	public SchemaServiceCreate getCreate() {
 		return create;
 	}

--- a/model/src/main/java/de/evoila/cf/broker/model/catalog/plan/SchemaServiceCreate.java
+++ b/model/src/main/java/de/evoila/cf/broker/model/catalog/plan/SchemaServiceCreate.java
@@ -7,6 +7,13 @@ public class SchemaServiceCreate {
 	@JsonProperty(value="parameters", required=false)
 	private SchemaParameters parameters;
 
+	public SchemaServiceCreate() {
+	}
+
+	public SchemaServiceCreate(SchemaParameters parameters) {
+		this.parameters = parameters;
+	}
+
 	public SchemaParameters getParameters() {
 		return parameters;
 	}

--- a/model/src/main/java/de/evoila/cf/broker/model/catalog/plan/SchemaServiceInstance.java
+++ b/model/src/main/java/de/evoila/cf/broker/model/catalog/plan/SchemaServiceInstance.java
@@ -10,6 +10,14 @@ public class SchemaServiceInstance {
 	@JsonProperty(value="update", required=false)
 	private SchemaServiceUpdate update;
 
+	public SchemaServiceInstance() {
+	}
+
+	public SchemaServiceInstance(SchemaServiceCreate create, SchemaServiceUpdate update) {
+		this.create = create;
+		this.update = update;
+	}
+
 	public SchemaServiceCreate getCreate() {
 		return create;
 	}

--- a/model/src/main/java/de/evoila/cf/broker/model/catalog/plan/SchemaServiceUpdate.java
+++ b/model/src/main/java/de/evoila/cf/broker/model/catalog/plan/SchemaServiceUpdate.java
@@ -7,6 +7,13 @@ public class SchemaServiceUpdate {
 	@JsonProperty(value="parameters", required=false)
 	private SchemaParameters parameters;
 
+	public SchemaServiceUpdate() {
+	}
+
+	public SchemaServiceUpdate(SchemaParameters parameters) {
+		this.parameters = parameters;
+	}
+
 	public SchemaParameters getParameters() {
 		return parameters;
 	}

--- a/model/src/main/java/de/evoila/cf/broker/model/catalog/plan/Schemas.java
+++ b/model/src/main/java/de/evoila/cf/broker/model/catalog/plan/Schemas.java
@@ -10,6 +10,14 @@ public class Schemas {
 	@JsonProperty(value="service_binding", required=false)
 	private SchemaServiceBinding serviceBinding;
 
+	public Schemas() {
+	}
+
+	public Schemas(SchemaServiceInstance serviceInstance, SchemaServiceBinding serviceBinding) {
+		this.serviceInstance = serviceInstance;
+		this.serviceBinding = serviceBinding;
+	}
+
 	public SchemaServiceInstance getServiceInstance() {
 		return serviceInstance;
 	}

--- a/model/src/main/java/de/evoila/cf/broker/model/cpi/EndpointServiceState.java
+++ b/model/src/main/java/de/evoila/cf/broker/model/cpi/EndpointServiceState.java
@@ -18,22 +18,18 @@ public class EndpointServiceState {
 	private AvailabilityState state;
 	
 	private String information;
-	
+
+	public EndpointServiceState(String identifier, AvailabilityState state) {
+		this(identifier, state, null);
+	}
+
 	public EndpointServiceState(String identifier, AvailabilityState state, String information) {
-		super();
 		this.identifier = identifier;
 		this.date = new Date();
 		this.state = state;
 		this.information = information;
 	}
 	
-	public EndpointServiceState(String identifier, AvailabilityState state) {
-		super();
-		this.identifier = identifier;
-		this.date = new Date();
-		this.state = state;
-	}
-
 	public String getIdentifier() {
 		return identifier;
 	}


### PR DESCRIPTION
- Remove super() constructor calls that call Object constructor
- Add constructors with no parameters where the default constructor is used
- Change variable visibility to private if no need for a different state was plausible
- Refactor some constructors to use constructor chaining instead of using duplicate code
- Remove autogenerated but not filled javaDoc structures
- Added serialVersionUID for exceptions that implemented a too simple one
- Changed import for @notempty from a deprecated to the suggested one
- Add getter and setter for classes that did rely on direct access

=> there might be a breaking change concerning classes that used direct access to its fields like ServiceInstanceBindingException, BoshProperties and EndpointCredential.

=> The class ServiceInstanceCreationResult has a typo for dashboard (daschboard), which is NOT fixed in this branch.