### PR TITLE
Change JSONCompareMode to fix the JsonSchemaTest

### DIFF
--- a/core/pom.xml
+++ b/core/pom.xml
@@ -91,6 +91,13 @@
             <groupId>com.github.everit-org.json-schema</groupId>
             <artifactId>org.everit.json.schema</artifactId>
             <version>1.10.0</version>
+            <!--
+            Needs following repository to be defined in the root pom:
+            <repository>
+                <id>jitpack.io</id>
+                <url>https://jitpack.io</url>
+            </repository>
+            -->
         </dependency>
 		<dependency>
 			<groupId>de.evoila.cf.broker</groupId>

--- a/model/src/test/java/de/evoila/cf/broker/model/schemas/JsonSchemaTest.java
+++ b/model/src/test/java/de/evoila/cf/broker/model/schemas/JsonSchemaTest.java
@@ -111,10 +111,9 @@ public class JsonSchemaTest {
 		assertFalse("Initial JSON and generated JSON should be unequal but are equal.", testPlanFromJson(file, false));
 	}
 	
-	/*
-	 * This methos checks for equality of two json Strings!
-	 * Hence changes in order of the json elements, although correct, will throw off this test.
-	 * Be aware of that, when using the test on other files.
+	/**
+	 * This method uses the JSONCompare class with the {@linkplain JSONCompareMode#NON_EXTENSIBLE}.
+	 * Therefore additional fields will cause the test to fail.
 	 */
 	public boolean testPlanFromJson(File file, boolean expectsEqual) throws IOException, JSONException {
 		ObjectMapper mapper = new ObjectMapper();
@@ -129,7 +128,7 @@ public class JsonSchemaTest {
                 .writeValueAsString(p));
 
         JSONCompareResult result =
-                JSONCompare.compareJSON(expected.toString(), value.toString(), JSONCompareMode.STRICT);
+                JSONCompare.compareJSON(expected.toString(), value.toString(), JSONCompareMode.NON_EXTENSIBLE);
 
         boolean equal = expected.equals(value);
 		if (expectsEqual && result.failed()) {


### PR DESCRIPTION
The JSONCompare uses the JSONCompareMode.STRICT, which can cause the test to fail, if two arrays are compared, based on the order of elements. This mode is changed to JSONCompareMode.NON_EXTENSIBLE.