### PR TITLE
Resolve authenticationEntryPoint bean conflict.

### DIFF
--- a/core/src/main/java/de/evoila/config/web/BasicAuthSecurityConfiguration.java
+++ b/core/src/main/java/de/evoila/config/web/BasicAuthSecurityConfiguration.java
@@ -48,7 +48,7 @@ public class BasicAuthSecurityConfiguration extends WebSecurityConfigurerAdapter
                 .csrf().disable();
     }
 
-    @Bean
+    @Bean (name = "basicAuthenticationEntryPoint")
     public AuthenticationEntryPoint authenticationEntryPoint() {
         BasicAuthenticationEntryPoint entryPoint =
                 new BasicAuthenticationEntryPoint();

--- a/core/src/main/java/de/evoila/config/web/UaaSecurityConfiguration.java
+++ b/core/src/main/java/de/evoila/config/web/UaaSecurityConfiguration.java
@@ -66,7 +66,7 @@ public class UaaSecurityConfiguration extends WebSecurityConfigurerAdapter {
                 .csrf().disable();
     }
 
-    @Bean
+    @Bean(name = "uaaAuthencationEntryPoint")
     public AuthenticationEntryPoint authenticationEntryPoint() {
         CommonCorsAuthenticationEntryPoint entryPoint =
                 new CommonCorsAuthenticationEntryPoint();


### PR DESCRIPTION
Due to the upgrade in the spring-boot-starter-parent version in the service brokers, a conflict of AuthenticationEntryPoint beans occurred. Naming these beans resolves the issue.