### PR TITLE
Add api interceptor logging

### DIFF
--- a/core/src/main/java/de/evoila/cf/broker/controller/core/ServiceInstanceController.java
+++ b/core/src/main/java/de/evoila/cf/broker/controller/core/ServiceInstanceController.java
@@ -158,7 +158,7 @@ public class ServiceInstanceController extends BaseController {
         ServiceDefinition serviceDefinition = catalogService.getServiceDefinition(serviceInstance.getServiceDefinitionId());
 
 		if (!(serviceDefinition.isInstancesRetrievable())) {
-			throw new ServiceInstanceNotRetrievableException("The Service Instance could not be retrievable. You should not attempt to call this endpoint");
+			throw new ServiceInstanceNotRetrievableException("The Service Instance is not retrievable. You should not attempt to call this endpoint");
 		}
 		ServiceInstanceResponse serviceInstanceResponse = new ServiceInstanceResponse(serviceInstance);
 

--- a/core/src/main/java/de/evoila/cf/broker/interceptor/ApiVersionInterceptor.java
+++ b/core/src/main/java/de/evoila/cf/broker/interceptor/ApiVersionInterceptor.java
@@ -69,6 +69,7 @@ public class ApiVersionInterceptor implements HandlerInterceptor {
             response.setContentType("application/json");
             response.setStatus(HttpServletResponse.SC_PRECONDITION_FAILED);
             response.sendError(HttpServletResponse.SC_PRECONDITION_FAILED, mapper.writeValueAsString(noHeaderFound));
+            log.info("Intercepted a request without an X-Broker-API-Version header.");
             return false;
         }
 
@@ -76,6 +77,7 @@ public class ApiVersionInterceptor implements HandlerInterceptor {
             response.setContentType("application/json");
             response.setStatus(HttpServletResponse.SC_PRECONDITION_FAILED);
             response.sendError(HttpServletResponse.SC_PRECONDITION_FAILED, mapper.writeValueAsString(headerValueNotAllowed));
+            log.info("Intercepted a request with a non-matching X-Broker-API-Version header (received "+requestApiVersion+" but method supports "+apis.toString()+").");
             return false;
         }
         return true;


### PR DESCRIPTION
The APIVersionInterceptor intercepts and returns request that do not hold any or a matching X-Broker-API-Version header. But this is not logged in an informative matter and can easily be overseen.

This PR adds two logging lines for clarification and comprehensibility of the intercepts.