### PR TITLE
Slimming the ServiceInstanceBindingController

### DIFF
--- a/core/src/main/java/de/evoila/cf/broker/controller/BaseController.java
+++ b/core/src/main/java/de/evoila/cf/broker/controller/BaseController.java
@@ -44,6 +44,11 @@ public abstract class BaseController {
         return processErrorResponse(HttpStatus.UNPROCESSABLE_ENTITY);
     }
 
+    @ExceptionHandler(ServiceBrokerFeatureIsNotSupportedException.class)
+    public ResponseEntity<ResponseMessage> handleException(ServiceBrokerFeatureIsNotSupportedException ex) {
+        return processErrorResponse(HttpStatus.UNPROCESSABLE_ENTITY);
+    }
+
     @ExceptionHandler({ ServiceDefinitionDoesNotExistException.class, ServiceInstanceNotRetrievableException.class })
     public ResponseEntity<ResponseMessage> handleException(Exception ex) {
         return processErrorResponse(ex.getMessage(), HttpStatus.BAD_REQUEST);
@@ -62,6 +67,21 @@ public abstract class BaseController {
     @ExceptionHandler(ServiceInstanceNotFoundException.class)
     public ResponseEntity<ResponseMessage> handleException(ServiceInstanceNotFoundException ex){
         return processErrorResponse(HttpStatus.NOT_FOUND);
+    }
+
+    @ExceptionHandler(ServiceInstanceBindingExistsException.class)
+    public ResponseEntity<ResponseMessage> handleException(ServiceInstanceBindingExistsException ex) {
+        return processErrorResponse(HttpStatus.CONFLICT);
+    }
+
+    @ExceptionHandler(ServiceInstanceBindingNotFoundException.class)
+    public ResponseEntity<ResponseMessage> handleException(ServiceInstanceBindingNotFoundException ex) {
+        return processErrorResponse(HttpStatus.NOT_FOUND);
+    }
+
+    @ExceptionHandler(ServiceInstanceBindingDoesNotExistsException.class)
+    public ResponseEntity<ResponseMessage> handleException(ServiceInstanceBindingDoesNotExistsException ex) {
+        return processErrorResponse(HttpStatus.GONE);
     }
 
 }

--- a/core/src/main/java/de/evoila/cf/broker/controller/core/ServiceInstanceBindingController.java
+++ b/core/src/main/java/de/evoila/cf/broker/controller/core/ServiceInstanceBindingController.java
@@ -148,33 +148,12 @@ public class ServiceInstanceBindingController extends BaseController {
 		return new ResponseEntity<>(response, HttpStatus.OK);
 	}
 
-	@ResponseBody
+
+	// Needed here instead of in the BaseController because a different status code has to be returned.
 	@ExceptionHandler(ServiceInstanceDoesNotExistException.class)
 	public ResponseEntity<ResponseMessage> handleException(ServiceInstanceDoesNotExistException ex) {
 		return processErrorResponse(HttpStatus.UNPROCESSABLE_ENTITY);
 	}
-	
-	@ResponseBody
-	@ExceptionHandler(ServiceBrokerFeatureIsNotSupportedException.class)
-	public ResponseEntity<ResponseMessage> handleException(ServiceBrokerFeatureIsNotSupportedException ex) {
-		return processErrorResponse(HttpStatus.UNPROCESSABLE_ENTITY);
-	}
 
-	@ResponseBody
-	@ExceptionHandler(ServiceInstanceBindingExistsException.class)
-	public ResponseEntity<ResponseMessage> handleException(ServiceInstanceBindingExistsException ex) {
-		return processErrorResponse(HttpStatus.CONFLICT);
-	}
 
-	@ResponseBody
-	@ExceptionHandler(ServiceInstanceBindingNotFoundException.class)
-	public ResponseEntity<ResponseMessage> handleException(ServiceInstanceBindingNotFoundException ex) {
-		return processErrorResponse(HttpStatus.NOT_FOUND);
-	}
-
-	@ResponseBody
-	@ExceptionHandler(ServiceInstanceBindingDoesNotExistsException.class)
-	public ResponseEntity<ResponseMessage> handleException(ServiceInstanceBindingDoesNotExistsException ex) {
-		return processErrorResponse(HttpStatus.GONE);
-	}
 }


### PR DESCRIPTION
The ServiceInstanceBindingController holds its own ExceptionHandlers despite extending the BaseController. 

This PR moves ExceptionHandler, that do not need to overwrite ExceptionHandlers of the Base Controller, into the BaseController.