### PR TITLE
Fetch Binding returns 500 error for Null Service Instance

### DIFF
--- a/core/src/main/java/de/evoila/cf/broker/service/impl/BindingServiceImpl.java
+++ b/core/src/main/java/de/evoila/cf/broker/service/impl/BindingServiceImpl.java
@@ -309,6 +309,8 @@ public abstract class BindingServiceImpl implements BindingService {
 		ServiceInstance serviceInstance;
 		try {
 			serviceInstance = serviceInstanceRepository.getServiceInstance(instanceId);
+			if (serviceInstance == null)
+				throw new ServiceInstanceDoesNotExistException(instanceId);
 		} catch(Exception e) {
 			throw new ServiceInstanceDoesNotExistException(instanceId);
 		}


### PR DESCRIPTION
Upon making a fetch binding request for a service instance, that does not exist, the osb-core returns a 500 Null Pointer error.

This is caused by a null value, that is returned by the ServiceInstanceRepositoryImpl from the osb-persistence submodule. If there is no value in the storage, a null pointer is returned, which the ServiceInstanceBindingController is calling a method upon. This causes the null pointer.

This PR adds simple null pointer check into throwing the expected and dedicated exception (although this is caught right away and thrown again).