### PR TITLE
Dodge deprecation of appGuid field in ServiceInstanceBindingRequest

### DIFF
--- a/model/src/main/java/de/evoila/cf/broker/model/ServiceInstanceBindingRequest.java
+++ b/model/src/main/java/de/evoila/cf/broker/model/ServiceInstanceBindingRequest.java
@@ -4,6 +4,7 @@ import com.fasterxml.jackson.annotation.JsonAutoDetect;
 import com.fasterxml.jackson.annotation.JsonAutoDetect.Visibility;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.databind.annotation.JsonSerialize;
+import org.springframework.util.StringUtils;
 
 import javax.validation.constraints.NotEmpty;
 import java.util.HashMap;
@@ -73,14 +74,33 @@ public class ServiceInstanceBindingRequest {
 		this.planId = planId;
 	}
 
-	@Deprecated
+	/**
+	 * Returns the app guid of the service instance binding request.
+	 * Due to the deprecated status of the field appGuid in this class, the Getter will try to access the
+	 * appGuid of its {@linkplain #bindResource} object. If the BindResource is null or its appGuid value is empty,
+	 * the field of this calls will be returned.
+	 * @return Id of the referenced application
+	 */
 	public String getAppGuid() {
+		if (bindResource != null && !StringUtils.isEmpty(bindResource.getAppGuid())) {
+			return bindResource.getAppGuid();
+		}
 		return appGuid;
 	}
 
-	@Deprecated
+	/**
+	 * Sets the app guid of the service instance binding request.
+	 * Due to the deprecated status of the field appGuid in this class, the Setter will also try to set the
+	 * appGuid of its {@linkplain #bindResource} object. This would cause calls of the {@linkplain #getAppGuid()}
+	 * to return the appGuid field of the {@linkplain #bindResource} object instead of the deprecated appGuid field
+	 * of this class.
+	 * @param appGuid String with the Id of the referenced application to set to
+	 */
 	public void setAppGuid(String appGuid) {
 		this.appGuid = appGuid;
+		if (bindResource != null) {
+			bindResource.setAppGuid(appGuid);
+		}
 	}
 
 	public Map<String, Object> getParameters() {

--- a/model/src/main/java/de/evoila/cf/broker/model/ServiceInstanceBindingRequest.java
+++ b/model/src/main/java/de/evoila/cf/broker/model/ServiceInstanceBindingRequest.java
@@ -81,6 +81,7 @@ public class ServiceInstanceBindingRequest {
 	 * the field of this calls will be returned.
 	 * @return Id of the referenced application
 	 */
+	@Deprecated
 	public String getAppGuid() {
 		if (bindResource != null && !StringUtils.isEmpty(bindResource.getAppGuid())) {
 			return bindResource.getAppGuid();
@@ -96,6 +97,7 @@ public class ServiceInstanceBindingRequest {
 	 * of this class.
 	 * @param appGuid String with the Id of the referenced application to set to
 	 */
+	@Deprecated
 	public void setAppGuid(String appGuid) {
 		this.appGuid = appGuid;
 		if (bindResource != null) {


### PR DESCRIPTION
This PR holds a little change to minimize the usage of the deprecated field "appGuid" in the ServiceInstanceBindingResponse without changing every Getter call in the core. In this way we support and use this field if necessary and not possible otherwise, but relay possible usages to the non-deprecated BindResource in the request class.

Please give me your opinion on this change, since it does break a little with the expectation of a Java Getter method.
Furthermore I was not completely sure, whether to leave the "@Deprecated" annotations on the methods, but removed them in this commit.