### PR TITLE
Add catalog validation skeleton and basic validation

### DIFF
--- a/core/src/main/java/de/evoila/cf/broker/service/CatalogValidationService.java
+++ b/core/src/main/java/de/evoila/cf/broker/service/CatalogValidationService.java
@@ -171,10 +171,22 @@ public class CatalogValidationService {
         return validateMaintenanceInfo(plan.getId(), plan.getMaintenanceInfo());
     }
 
+    /**
+     * Validates a given String to be a GUID.
+     * @param guid string to validate
+     * @return true if the given string qualifies for a GUID and false if it does not
+     */
     private boolean validateGuid(String guid) {
         return !StringUtils.isEmpty(guid) && guid.matches(GUID_REGEX);
     }
 
+    /**
+     * Validates a given maintenance_info object by checking its version for existence
+     * and compliance with Semantic Version 2
+     * @param planId id of the owning plan for logging purposes
+     * @param maintenanceInfo maintenance_info object to validate
+     * @return true if the given maintenance_info is valid or false if it is not
+     */
     private boolean validateMaintenanceInfo(String planId, MaintenanceInfo maintenanceInfo) {
         if (maintenanceInfo == null) return true;
 
@@ -190,6 +202,12 @@ public class CatalogValidationService {
         return true;
     }
 
+    /**
+     * Logs the incorrect version with the given id of the plan object owning maintenance_info object.
+     * Also logs a few examples of Semantic Versioning 2 to help the user with changing the version.
+     * @param planId id of the plan object, that owns the maintenance_info object
+     * @param version incorrect version string
+     */
     private void logIncorrectSemverVersion(String planId, String version){
         log.info("\n######################"
                 + "\n The version of the maintenance_info object for plan " + planId + " is not complying to required Semantic Versioning 2.0.0"
@@ -202,10 +220,19 @@ public class CatalogValidationService {
                 + "\n######################");
     }
 
+    /**
+     * Logs the absence of the {@linkplain MaintenanceInfo#getVersion()} field.
+     * @param planId id of the plan object, that owns the maintenance_info object
+     */
     private void logVersionFieldDoesNotExist(String planId) {
         log.info("Version field of maintenance_info for plan " + planId + " is not set, but necessary if the object exists.");
     }
 
+    /**
+     * Validates a String to qualify as a Semantic Versioning 2 version.
+     * @param versionToCheck the version String to check
+     * @return true if given version String is Semantic Versioning 2
+     */
     private boolean validateSemanticVersion2(String versionToCheck) {
         return !StringUtils.isEmpty(versionToCheck) &&
                 versionToCheck.matches("^(0|[1-9]\\d*)" +

--- a/core/src/main/java/de/evoila/cf/broker/service/CatalogValidationService.java
+++ b/core/src/main/java/de/evoila/cf/broker/service/CatalogValidationService.java
@@ -144,7 +144,10 @@ public class CatalogValidationService {
             return false;
         }
 
-        if (serviceDefinition.getPlans() == null) return true;
+        if (serviceDefinition.getPlans() == null || serviceDefinition.getPlans().isEmpty()) {
+            log.info("Service definition " + serviceDefinition.getId() + " has no plans.");
+            return false;
+        }
 
         // Foreach instead of Stream because of accessing a variable outside of the stream
         boolean valid = true;

--- a/core/src/main/java/de/evoila/cf/broker/service/CatalogValidationService.java
+++ b/core/src/main/java/de/evoila/cf/broker/service/CatalogValidationService.java
@@ -106,6 +106,8 @@ public class CatalogValidationService {
                 log.info("Invalid parts were changed or disabled to ensure a proper start and runtime. " +
                         "Please review the catalog or logs of class 'CatalogValidationService' to see which parts were changed or disabled.");
             }
+        } else {
+            log.info("Catalog was validated and passed.");
         }
 
         return valid;
@@ -131,6 +133,14 @@ public class CatalogValidationService {
 
         if (!validateGuid(serviceDefinition.getId())) {
             log.info("Id of a service definition is not a valid guid (name = " + serviceDefinition.getName() + ")");
+            return false;
+        }
+        if (StringUtils.isEmpty(serviceDefinition.getName())) {
+            log.info("Name of service definition " + serviceDefinition.getId() + " is null or empty.");
+            return false;
+        }
+        if (StringUtils.isEmpty(serviceDefinition.getDescription())) {
+            log.info("Description of service definition " + serviceDefinition.getId() + " is null or empty.");
             return false;
         }
 
@@ -162,6 +172,14 @@ public class CatalogValidationService {
 
         if (!validateGuid(plan.getId())) {
             log.info("Id of a plan is not a valid guid (name = " + plan.getName() + ")");
+            return false;
+        }
+        if (StringUtils.isEmpty(plan.getName())) {
+            log.info("Name of plan " + plan.getId() + " is null or empty.");
+            return false;
+        }
+        if (StringUtils.isEmpty(plan.getDescription())) {
+            log.info("Description of plan " + plan.getId() + " is null or empty.");
             return false;
         }
 

--- a/core/src/main/java/de/evoila/cf/broker/service/CatalogValidationService.java
+++ b/core/src/main/java/de/evoila/cf/broker/service/CatalogValidationService.java
@@ -1,0 +1,227 @@
+package de.evoila.cf.broker.service;
+
+import de.evoila.cf.broker.exception.CatalogIsNotValidException;
+import de.evoila.cf.broker.model.catalog.Catalog;
+import de.evoila.cf.broker.model.catalog.MaintenanceInfo;
+import de.evoila.cf.broker.model.catalog.ServiceDefinition;
+import de.evoila.cf.broker.model.catalog.plan.Plan;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnBean;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
+import org.springframework.boot.context.properties.ConfigurationProperties;
+import org.springframework.stereotype.Service;
+import org.springframework.util.StringUtils;
+
+import javax.annotation.PostConstruct;
+
+@Service
+@ConditionalOnBean(CatalogService.class)
+@ConditionalOnProperty(prefix = "config.catalog", name = "validate", havingValue = "true")
+@ConfigurationProperties(prefix = "config.catalog")
+public class CatalogValidationService {
+
+    public static String GUID_REGEX = "(\\{){0,1}[0-9a-fA-F]{8}\\-[0-9a-fA-F]{4}\\-[0-9a-fA-F]{4}\\-[0-9a-fA-F]{4}\\-[0-9a-fA-F]{12}(\\}){0,1}";
+
+    static Logger log = LoggerFactory.getLogger(CatalogValidationService.class);
+
+    private boolean validate;
+    private boolean strict;
+    private boolean intrusive;
+
+    private CatalogService catalogService;
+
+    public CatalogValidationService(CatalogService catalogService) {
+        this.catalogService = catalogService;
+    }
+
+    public boolean isValidate() {
+        return validate;
+    }
+
+    public void setValidate(boolean validate) {
+        this.validate = validate;
+    }
+
+    public boolean isStrict() {
+        return strict;
+    }
+
+    public void setStrict(boolean strict) {
+        this.strict = strict;
+    }
+
+    public boolean isIntrusive() {
+        return intrusive;
+    }
+
+    public void setIntrusive(boolean intrusive) {
+        this.intrusive = intrusive;
+    }
+
+    public boolean isAllowedToChangeCatalog() {
+        return !strict && intrusive;
+    }
+
+    /**
+     * Method for Spring to run a validation on startup.
+     * If the service is configured as {@linkplain #isStrict()}, the method will throw an uncaught {@linkplain CatalogIsNotValidException}.
+     * The catalog will be provided by the {@linkplain CatalogService}.
+     * For further information see {@linkplain #validateCatalog(Catalog)}.
+     * @throws CatalogIsNotValidException
+     */
+    @PostConstruct
+    public void validate() throws CatalogIsNotValidException {
+        Catalog catalog = catalogService.getCatalog();
+        if (!validateCatalog(catalog) && strict) {
+            throw new CatalogIsNotValidException("The catalog that was build on the given configuration is not valid. " +
+                    "Please see the logs of class 'CatalogValidationService' to identify flawed or missing fields.");
+        }
+    }
+
+    /**
+     * Runs a validation check on the given catalog. This includes following steps:
+     * <ul>
+     *     <li>null check</li>
+     *     <li>has at least one service definition</li>
+     *     <li>{@linkplain #validateServiceDefinition(ServiceDefinition)} for each service definition</li>
+     * </ul>
+     * If the service {@linkplain #isAllowedToChangeCatalog()}, then fields can be changed or parts disabled to prevent misconfiguration.
+     * @param catalog Catalog object to validate
+     * @return true if the catalog is valid according to the performed checks or false if at least one check fails
+     */
+    public boolean validateCatalog(Catalog catalog) {
+        if (catalog == null || catalog.getServices() == null || catalog.getServices().size() == 0) {
+            log.info("Catalog is null or the catalog holds no services.");
+            return false;
+        }
+
+        boolean valid = true;
+        for (ServiceDefinition serviceDefinition : catalog.getServices()) {
+            valid &= validateServiceDefinition(serviceDefinition);
+        }
+        if (!valid) {
+            log.info("The catalog that was build on the given configuration is not valid.");
+            if (isAllowedToChangeCatalog()) {
+                log.info("Invalid parts were changed or disabled to ensure a proper start and runtime. " +
+                        "Please review the catalog or logs of class 'CatalogValidationService' to see which parts were changed or disabled.");
+            }
+        }
+
+        return valid;
+    }
+
+    /**
+     * Runs a validation check on the given service definition. This includes following steps:
+     * <ul>
+     *     <li>null check</li>
+     *     <li>{@linkplain #validateGuid(String)} for the id</li>
+     *     <li>{@linkplain #validateServicePlan(Plan)} for each plan</li>
+     * </ul>
+     *
+     * If the service {@linkplain #isAllowedToChangeCatalog()}, then fields can be changed or parts disabled to prevent misconfiguration.
+     * @param serviceDefinition ServiceDefinition object to validate
+     * @return true if the service definition is valid according to the performed checks or false if at least one check fails
+     */
+    public boolean validateServiceDefinition(ServiceDefinition serviceDefinition) {
+        if (serviceDefinition == null) {
+            log.info("The catalog contains a service definition that is a null value");
+            return false;
+        }
+
+        if (!validateGuid(serviceDefinition.getId())) {
+            log.info("Id of a service definition is not a valid guid (name = " + serviceDefinition.getName() + ")");
+            return false;
+        }
+
+        if (serviceDefinition.getPlans() == null) return true;
+
+        // Foreach instead of Stream because of accessing a variable outside of the stream
+        boolean valid = true;
+        for (Plan plan : serviceDefinition.getPlans()) {
+            valid &= validateServicePlan(plan);
+        }
+        return valid;
+    }
+
+    /**
+     * Runs a validation check on the given service plan. This includes following steps:
+     * <ul>
+     *     <li>null check</li>
+     *     <li>{@linkplain #validateGuid(String)} for the id</li>
+     *     <li>{@linkplain #validateMaintenanceInfo(Plan)} for the maintenance info object</li>
+     * </ul>
+     * @param plan
+     * @return
+     */
+    public boolean validateServicePlan(Plan plan) {
+        if (plan == null) {
+            log.info("A service definition contains a plan that is a null value");
+            return false;
+        }
+
+        if (!validateGuid(plan.getId())) {
+            log.info("Id of a plan is not a valid guid (name = " + plan.getName() + ")");
+            return false;
+        }
+
+        return validateMaintenanceInfo(plan);
+    }
+
+    private boolean validateGuid(String guid) {
+        return !StringUtils.isEmpty(guid) && guid.matches(GUID_REGEX);
+    }
+
+    private boolean validateMaintenanceInfo(Plan plan) {
+        if (plan == null) {
+            log.info("A plan is null.");
+            return false;
+        }
+
+        if (plan.getMaintenanceInfo() == null) return true;
+
+        MaintenanceInfo maintenanceInfo = plan.getMaintenanceInfo();
+
+        if (StringUtils.isEmpty(maintenanceInfo.getVersion())) {
+            logVersionFieldDoesNotExist(plan.getId());
+            if (isAllowedToChangeCatalog()) {
+                plan.setMaintenanceInfo(null);
+            }
+            return false;
+        }
+
+        if (!validateSemanticVersion2(maintenanceInfo.getVersion())){
+            logIncorrectSemverVersion(plan.getId(), maintenanceInfo.getVersion());
+            if (isAllowedToChangeCatalog()) {
+                plan.setMaintenanceInfo(null);
+            }
+            return false;
+        }
+        return true;
+    }
+
+    private void logIncorrectSemverVersion(String planId, String version){
+        log.info("\n######################"
+                + "\n The version of the maintenance_info object for plan " + planId + " is not complying to required Semantic Versioning 2.0.0"
+                + "\n The version should look like following examples:"
+                + "\n- 1.2.3 "
+                + "\n- 2.0.0"
+                + "\n- 2.2.1-rc.1"
+                + "\n- 1.0.0-beta"
+                + "\nPlease change your current value '" + version + "' to a compatible string."
+                + "\n######################");
+    }
+
+    private void logVersionFieldDoesNotExist(String planId) {
+        log.info("Version field of maintenance_info for plan " + planId + " is not set, but necessary if the object exists.");
+    }
+
+    private boolean validateSemanticVersion2(String versionToCheck) {
+        return !StringUtils.isEmpty(versionToCheck) &&
+                versionToCheck.matches("^(0|[1-9]\\d*)" +
+                        "\\.(0|[1-9]\\d*)" +
+                        "\\.(0|[1-9]\\d*)" +
+                        "(?:-((?:0|[1-9]\\d*|\\d*[a-zA-Z-][0-9a-zA-Z-]*)(?:\\.(?:0|[1-9]\\d*|\\d*[a-zA-Z-][0-9a-zA-Z-]*))*))" +
+                        "?(?:\\+([0-9a-zA-Z-]+(?:\\.[0-9a-zA-Z-]+)*))?$");
+    }
+}

--- a/core/src/main/java/de/evoila/cf/broker/service/impl/CatalogServiceImpl.java
+++ b/core/src/main/java/de/evoila/cf/broker/service/impl/CatalogServiceImpl.java
@@ -40,7 +40,7 @@ public class CatalogServiceImpl implements CatalogService {
 
 	private EndpointConfiguration endpointConfiguration;
 
-	public CatalogServiceImpl(Catalog catalog, Environment environment, EndpointConfiguration endpointConfiguration, @Autowired(required = false ) List<TranformCatalog> tranformCatalog) throws CatalogIsNotValidException {
+	public CatalogServiceImpl(Catalog catalog, Environment environment, EndpointConfiguration endpointConfiguration, @Autowired(required = false ) List<TranformCatalog> tranformCatalog) {
 		this.catalog = catalog;
 		this.environment = environment;
 		this.endpointConfiguration = endpointConfiguration;

--- a/core/src/test/java/de/evoila/cf/broker/service/CatalogValidationServiceTest.java
+++ b/core/src/test/java/de/evoila/cf/broker/service/CatalogValidationServiceTest.java
@@ -1,0 +1,261 @@
+package de.evoila.cf.broker.service;
+
+import de.evoila.cf.broker.exception.CatalogIsNotValidException;
+import de.evoila.cf.broker.model.Platform;
+import de.evoila.cf.broker.model.catalog.Catalog;
+import de.evoila.cf.broker.model.catalog.MaintenanceInfo;
+import de.evoila.cf.broker.model.catalog.ServiceDefinition;
+import de.evoila.cf.broker.model.catalog.plan.Cost;
+import de.evoila.cf.broker.model.catalog.plan.Metadata;
+import de.evoila.cf.broker.model.catalog.plan.Plan;
+import de.evoila.cf.broker.service.impl.CatalogServiceImpl;
+import org.junit.Before;
+import org.junit.BeforeClass;
+import org.junit.Test;
+
+import java.util.Arrays;
+import java.util.LinkedList;
+import java.util.UUID;
+
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.fail;
+import static org.springframework.test.util.AssertionErrors.assertTrue;
+
+public class CatalogValidationServiceTest {
+
+    private Catalog catalog;
+    private CatalogValidationService catalogValidationService;
+
+    @Before
+    public void initCatalog() {
+
+        Plan planA = getTestPlan(
+                UUID.randomUUID().toString(),
+                "test_plan_A",
+                "This plan is a valid test plan.",
+                Platform.EXISTING_SERVICE,
+                true,
+                "1.0.0-beta"
+        );
+        Plan planB = getTestPlan(
+                UUID.randomUUID().toString(),
+                "test_plan_B",
+                "This plan is a valid test plan.",
+                Platform.BOSH,
+                false,
+                "2.4.1-rc.1"
+        );
+        Plan planC = getTestPlan(
+                UUID.randomUUID().toString(),
+                "test_plan_C",
+                "This plan is a valid test plan.",
+                Platform.EXISTING_SERVICE,
+                false,
+                "3.12.1"
+        );
+
+        ServiceDefinition serviceDefinition = new ServiceDefinition(
+                UUID.randomUUID().toString(),
+                "valid_test_service_definition",
+                "This is a valid test service definition.",
+                true,
+                Arrays.asList(planA, planB, planC),
+                true
+        );
+
+        catalog = new Catalog();
+        catalog.setServices(Arrays.asList(serviceDefinition));
+
+        catalogValidationService = new CatalogValidationService(null);
+        catalogValidationService.setStrict(true);
+        catalogValidationService.setValidate(true);
+        catalogValidationService.setIntrusive(false);
+    }
+
+    private Plan getTestPlan(String id, String name, String description, Platform platform, boolean free, String maintenanceVersion) {
+        Plan plan = new Plan(id, name, description, platform, free);
+        Metadata metadata = new Metadata();
+        plan.setMetadata(metadata);
+        metadata.setBullets(Arrays.asList("testing_" + name, "test_" + name , "no real value"));
+        metadata.setDisplayName(name + "_displayname");
+        metadata.setActive(true);
+        plan.setMaintenanceInfo(new MaintenanceInfo(maintenanceVersion, "First beta release"));
+
+        return plan;
+    }
+
+    private Plan getPlan(int index) {
+        return catalog.getServices().get(0).getPlans().get(index);
+    }
+
+    private ServiceDefinition getServiceDefinition() {
+        return catalog.getServices().get(0);
+    }
+
+    /**
+     * Executes assertion commands for the catalog, the service definition and plans A, B and C.
+     * When expecting a negative validation, this method only takes one plan into consideration when changed.
+     * @param expected whether to expect a valid or invalid catalog
+     * @param nameOfChangedObject name of the object that was changed for logging purposes
+     * @param indexOfChangedPlan indicates which plan was made invalid, insert a number which is no index in the plans list like -1
+     */
+    public void assertCatalogComponents(boolean expected, String nameOfChangedObject, int indexOfChangedPlan) {
+        if (expected) {
+            assertTrue("Default tested catalog should be valid but was not.",
+                    catalogValidationService.validateCatalog(catalog));
+
+            assertTrue("Default tested service definition should be valid but was not.",
+                    catalogValidationService.validateServiceDefinition(getServiceDefinition()));
+
+
+            getServiceDefinition().getPlans().forEach(plan -> {
+                assertTrue("Default tested plan "+ plan.getName() + " should be valid but is not.",
+                        catalogValidationService.validateServicePlan(plan));
+            });
+        } else {
+            assertFalse("Catalog should be invalid after changes to " + nameOfChangedObject + " but is not.",
+                    catalogValidationService.validateCatalog(catalog));
+            assertFalse("Service definition should be invalid after changes to " + nameOfChangedObject + " but is not.",
+                    catalogValidationService.validateServiceDefinition(getServiceDefinition()));
+
+            if (indexOfChangedPlan == 0) {
+                assertFalse("Plan A should be invalid after changes to " + nameOfChangedObject + " but is not.",
+                        catalogValidationService.validateServicePlan(getPlan(0)));
+            } else {
+                assertTrue("Plan A should still be valid after changes to " + nameOfChangedObject + " but is not.",
+                        catalogValidationService.validateServicePlan(getPlan(0)));
+            }
+
+            if (indexOfChangedPlan == 1) {
+                assertFalse("Plan B should be invalid after changes to " + nameOfChangedObject + " but is not.",
+                        catalogValidationService.validateServicePlan(getPlan(1)));
+            } else {
+                assertTrue("Plan B should still be valid after changes to " + nameOfChangedObject + " but is not.",
+                        catalogValidationService.validateServicePlan(getPlan(1)));
+            }
+
+            if (indexOfChangedPlan == 2) {
+                assertFalse("Plan C should be invalid after changes to " + nameOfChangedObject + " but is not.",
+                        catalogValidationService.validateServicePlan(getPlan(2)));
+            } else {
+                assertTrue("Plan C should still be valid after changes to " + nameOfChangedObject + " but is not.",
+                        catalogValidationService.validateServicePlan(getPlan(2)));
+            }
+        }
+    }
+
+    @Test
+    public void testValidDefault() {
+        assertCatalogComponents(true, "", -1);
+    }
+
+    @Test
+    public void testInvalidPlans() {
+        // Test non guid id
+        Plan planInvalid = getPlan(0);
+        planInvalid.setId("nonsense####");
+        assertCatalogComponents(false, "plan A", 0);
+
+        // Test name equals null
+        initCatalog();
+        planInvalid = getPlan(1);
+        planInvalid.setName(null);
+        assertCatalogComponents(false, "plan B", 1);
+
+        // Test empty name
+        initCatalog();
+        planInvalid = getPlan(2);
+        planInvalid.setName("");
+        assertCatalogComponents(false, "plan C", 2);
+
+        // Test description equals null
+        initCatalog();
+        planInvalid = getPlan(0);
+        planInvalid.setDescription(null);
+        assertCatalogComponents(false, "plan A", 0);
+
+        // Test empty description
+        initCatalog();
+        planInvalid = getPlan(1);
+        planInvalid.setDescription("");
+        assertCatalogComponents(false, "plan B", 1);
+
+        // Test maintenance_info version being not semantic version 2
+        initCatalog();
+        planInvalid = getPlan(2);
+        MaintenanceInfo maintenanceInfo = planInvalid.getMaintenanceInfo();
+        maintenanceInfo.setVersion("nonsense#again");
+        assertCatalogComponents(false, "plan C's maintenance_info", 2);
+    }
+
+    @Test
+    public void testInvalidServiceDefinition() {
+        // Test non guid id
+        ServiceDefinition definitionInvalid = getServiceDefinition();
+        definitionInvalid.setId("nonsense####");
+        assertCatalogComponents(false, "service definition", -1);
+
+        // Test name equals null
+        initCatalog();
+        definitionInvalid = getServiceDefinition();
+        definitionInvalid.setName(null);
+        assertCatalogComponents(false, "service definition", -1);
+
+        // Test empty name
+        initCatalog();
+        definitionInvalid = getServiceDefinition();
+        definitionInvalid.setName("");
+        assertCatalogComponents(false, "service definition", -1);
+
+        // Test description equals null
+        initCatalog();
+        definitionInvalid = getServiceDefinition();
+        definitionInvalid.setDescription(null);
+        assertCatalogComponents(false, "service definition", -1);
+
+        // Test empty description
+        initCatalog();
+        definitionInvalid = getServiceDefinition();
+        definitionInvalid.setDescription("");
+        assertCatalogComponents(false, "service definition", -1);
+
+        // Test empty plan list
+        initCatalog();
+        definitionInvalid = getServiceDefinition();
+        definitionInvalid.setPlans(new LinkedList<>());
+        assertCatalogComponents(false, "service definition", -1);
+    }
+
+    @Test
+    public void testInvalidCatalog() {
+        catalog.setServices(null);
+        assertFalse("Catalog has null for services list but passed validation.", catalogValidationService.validateCatalog(catalog));
+
+        initCatalog();
+        catalog.setServices(new LinkedList<>());
+        assertFalse("Catalog has no service definitions but passed validation.", catalogValidationService.validateCatalog(catalog));
+    }
+
+    @Test(expected = CatalogIsNotValidException.class)
+    public void testValidationExceptionThrown() throws CatalogIsNotValidException {
+        CatalogService catalogService = new CatalogService() {
+            @Override
+            public Catalog getCatalog() {
+                Catalog catalog = new Catalog();
+                catalog.setServices(null);
+                return catalog;
+            }
+
+            @Override
+            public ServiceDefinition getServiceDefinition(String serviceId) {
+                return null;
+            }
+        };
+        catalogValidationService = new CatalogValidationService(catalogService);
+        catalogValidationService.setValidate(true);
+        catalogValidationService.setStrict(true);
+
+        catalogValidationService.validate();
+    }
+
+}

--- a/core/src/test/java/de/evoila/cf/broker/service/CatalogValidationServiceTest.java
+++ b/core/src/test/java/de/evoila/cf/broker/service/CatalogValidationServiceTest.java
@@ -118,6 +118,10 @@ public class CatalogValidationServiceTest {
             assertFalse("Service definition should be invalid after changes to " + nameOfChangedObject + " but is not.",
                     catalogValidationService.validateServiceDefinition(getServiceDefinition()));
 
+            if (getServiceDefinition().getPlans() == null || getServiceDefinition().getPlans().isEmpty()) {
+                return;
+            }
+                
             if (indexOfChangedPlan == 0) {
                 assertFalse("Plan A should be invalid after changes to " + nameOfChangedObject + " but is not.",
                         catalogValidationService.validateServicePlan(getPlan(0)));

--- a/model/src/main/java/de/evoila/cf/broker/exception/CatalogIsNotValidException.java
+++ b/model/src/main/java/de/evoila/cf/broker/exception/CatalogIsNotValidException.java
@@ -1,0 +1,12 @@
+package de.evoila.cf.broker.exception;
+
+public class CatalogIsNotValidException extends Exception {
+
+    public CatalogIsNotValidException(){
+        super();
+    }
+
+    public CatalogIsNotValidException(String message) {
+        super(message);
+    }
+}


### PR DESCRIPTION
This PR implements a basic validation of the catalog. On startup a dedicated service checks the catalog of the CatalogService. The check contains catalog object, service definition objects and service plans objects validation. For now existence (null), ids and maintenance info are being validated.

The broker logs the validation errors for the developer or user to correct the flaws and errors.
 
The validation is configurable like so:
- boolean validate -> flag to enable / disable catalog validation
- boolean strict -> throws an Exception if not valid and will prevent startup completion
- boolean intrusive -> allows the broker to change or disable parts of the catalog
