### PR TITLE
Add No-op update identification

### DIFF
--- a/core/src/main/java/de/evoila/cf/broker/util/ServiceInstanceUtils.java
+++ b/core/src/main/java/de/evoila/cf/broker/util/ServiceInstanceUtils.java
@@ -110,8 +110,7 @@ public class ServiceInstanceUtils {
      * @return true if update would have effects and false if it would not
      */
     public static boolean isEffectivelyUpdating(ServiceInstance serviceInstance, ServiceInstanceUpdateRequest request) {
-        if (serviceInstance == null && request == null) return false;
-        if (serviceInstance == null ^ request == null) return true;
+        if (serviceInstance == null || request == null) return false;
         if (request.getContext() == null ^ serviceInstance.getContext() == null) return true;
         if (request.getParameters() == null ^ serviceInstance.getParameters() == null) return true;
 

--- a/core/src/main/java/de/evoila/cf/broker/util/ServiceInstanceUtils.java
+++ b/core/src/main/java/de/evoila/cf/broker/util/ServiceInstanceUtils.java
@@ -1,5 +1,7 @@
 package de.evoila.cf.broker.util;
 
+import de.evoila.cf.broker.model.ServiceInstance;
+import de.evoila.cf.broker.model.ServiceInstanceUpdateRequest;
 import de.evoila.cf.broker.model.catalog.ServerAddress;
 import org.springframework.util.StringUtils;
 
@@ -95,5 +97,29 @@ public class ServiceInstanceUtils {
 
     public static ServerAddress serverAddress(String name, String host, int port) {
         return new ServerAddress(name, host, port);
+    }
+
+    /**
+     * Checks whether an update with the given ServiceInstanceUpdateRequest would effectively change the service instance.
+     *
+     * This method heavily relies on the {@linkplain Object#equals(Object)} method to check for equality
+     * and resulting non-effective changes to a field. So it is mandatory for all objects contained in
+     * {@linkplain ServiceInstance#getParameters()} to have an overwritten equals method or can ensure equality by identity.
+     * @param serviceInstance the service instance object to compare with the update request
+     * @param request the update request object to compare with the service instance
+     * @return true if update would have effects and false if it would not
+     */
+    public static boolean isEffectivelyUpdating(ServiceInstance serviceInstance, ServiceInstanceUpdateRequest request) {
+        if (serviceInstance == null && request == null) return false;
+        if (serviceInstance == null ^ request == null) return true;
+        if (request.getContext() == null ^ serviceInstance.getContext() == null) return true;
+        if (request.getParameters() == null ^ serviceInstance.getParameters() == null) return true;
+
+        if (!request.getServiceDefinitionId().equals(serviceInstance.getServiceDefinitionId())
+            || !request.getPlanId().equals(serviceInstance.getPlanId()))
+            return true;
+
+        return !request.getContext().equals(serviceInstance.getContext())
+                || !request.getParameters().equals(serviceInstance.getParameters());
     }
 }

--- a/core/src/main/java/de/evoila/cf/broker/util/ServiceInstanceUtils.java
+++ b/core/src/main/java/de/evoila/cf/broker/util/ServiceInstanceUtils.java
@@ -102,12 +102,14 @@ public class ServiceInstanceUtils {
     /**
      * Checks whether an update with the given ServiceInstanceUpdateRequest would effectively change the service instance.
      *
+     * If either of the two values is null, the return value is always false.
+     *
      * This method heavily relies on the {@linkplain Object#equals(Object)} method to check for equality
      * and resulting non-effective changes to a field. So it is mandatory for all objects contained in
      * {@linkplain ServiceInstance#getParameters()} to have an overwritten equals method or can ensure equality by identity.
      * @param serviceInstance the service instance object to compare with the update request
      * @param request the update request object to compare with the service instance
-     * @return true if update would have effects and false if it would not
+     * @return true if update would have effects and false if it would not or a parameter is null
      */
     public static boolean isEffectivelyUpdating(ServiceInstance serviceInstance, ServiceInstanceUpdateRequest request) {
         if (serviceInstance == null || request == null) return false;

--- a/model/src/main/java/de/evoila/cf/broker/exception/ServiceInstanceNotFoundException.java
+++ b/model/src/main/java/de/evoila/cf/broker/exception/ServiceInstanceNotFoundException.java
@@ -1,5 +1,7 @@
 package de.evoila.cf.broker.exception;
 
+import org.springframework.util.StringUtils;
+
 /**
  * @author Marco Di Martino
  */
@@ -8,9 +10,15 @@ public class ServiceInstanceNotFoundException extends Exception {
 
     private static final long serialVersionUID = -5984853893472349837L;
 
-    @Override
-    public String getMessage() {
-        return "Service Instance does not exists or an operation for this Instance is still in progress.";
+    public ServiceInstanceNotFoundException() {
+        this("");
     }
+
+    public ServiceInstanceNotFoundException(String serviceInstanceId) {
+        super("Service Instance "
+                + (StringUtils.isEmpty(serviceInstanceId)? "" : serviceInstanceId + " ")
+                + "does not exists or an operation for this Instance is still in progress.");
+    }
+
 }
 


### PR DESCRIPTION
This PR contains changes to identify no-op updates and return a 200 in this case. The identification is done based on the request body and the affected service instance.

According to: https://github.com/openservicebrokerapi/servicebroker/blob/master/spec.md#response-5