### PR TITLE
Fix behavior for provision requests while provisioning is in progress

### DIFF
--- a/core/src/main/java/de/evoila/cf/broker/service/impl/DeploymentServiceImpl.java
+++ b/core/src/main/java/de/evoila/cf/broker/service/impl/DeploymentServiceImpl.java
@@ -82,6 +82,12 @@ public class DeploymentServiceImpl implements DeploymentService {
 		serviceDefinitionRepository.validateServiceId(request.getServiceDefinitionId());
 
 		if (serviceInstanceRepository.containsServiceInstanceId(serviceInstanceId)) {
+		    JobProgress jobProgress = jobRepository.getJobProgressByReferenceId(serviceInstanceId);
+		    if (jobProgress != null && jobProgress.isProvisioning() && jobProgress.isInProgress()) {
+		        // Service Instance can not be null, because containsServiceInstanceId check was done before
+                return new ServiceInstanceOperationResponse(jobProgress.getId(),
+                        serviceInstanceRepository.getServiceInstance(serviceInstanceId).getDashboardUrl(), true);
+            }
 			throw new ServiceInstanceExistsException(serviceInstanceId, request.getServiceDefinitionId());
 		}
 

--- a/model/src/main/java/de/evoila/cf/broker/model/JobProgress.java
+++ b/model/src/main/java/de/evoila/cf/broker/model/JobProgress.java
@@ -36,6 +36,11 @@ public class JobProgress implements BaseEntity<String> {
 	
 	private String description;
 
+	/**
+	 * This field describes the kind of operation this object describes, not the "operation" field for the response to the platform!
+	 * Use id to return to the platform as "operation" field in the json.
+	 *
+	 */
 	private String operation;
 
 	private String referenceId;
@@ -89,6 +94,11 @@ public class JobProgress implements BaseEntity<String> {
 		this.description = description;
 	}
 
+	/**
+	 * Returns the {@linkplain #operation} that describes the kind of operation.
+	 * See {@linkplain #PROVISION}, {@linkplain #UPDATE}, {@linkplain #DELETE}, {@linkplain #BIND} and {@linkplain #UNBIND} for values to expect.
+	 * @return description string for the current kind of operation
+	 */
 	public String getOperation() {
 		return operation;
 	}
@@ -104,4 +114,36 @@ public class JobProgress implements BaseEntity<String> {
     public void setReferenceId(String referenceId) {
         this.referenceId = referenceId;
     }
+
+    public boolean isInProgress() {
+		return IN_PROGRESS.equals(state);
+	}
+
+	public boolean isFailed() {
+		return FAILED.equals(state);
+	}
+
+	public boolean isSucceeded() {
+		return SUCCESS.equals(state);
+	}
+
+	public boolean isProvisioning() {
+		return PROVISION.equals(operation);
+	}
+
+	public boolean isUpdating() {
+		return UPDATE.equals(operation);
+	}
+
+	public boolean isDeleting() {
+		return DELETE.equals(operation);
+	}
+
+	public boolean isBinding() {
+		return BIND.equals(operation);
+	}
+
+	public boolean isUnbinding() {
+		return UNBIND.equals(operation);
+	}
 }

--- a/model/src/main/java/de/evoila/cf/broker/model/ServiceInstanceOperationResponse.java
+++ b/model/src/main/java/de/evoila/cf/broker/model/ServiceInstanceOperationResponse.java
@@ -24,12 +24,17 @@ public class ServiceInstanceOperationResponse {
 	public ServiceInstanceOperationResponse() {}
 
     public ServiceInstanceOperationResponse(String operation) {
-        this.operation = operation;
+        this(operation, "");
     }
 
     public ServiceInstanceOperationResponse(String operation, String dashboardUrl) {
-        this.operation = operation;
-        this.dashboardUrl = dashboardUrl;
+        this(operation, dashboardUrl, false);
+    }
+
+    public ServiceInstanceOperationResponse(String operation, String dashboardUrl, boolean isAsync) {
+	    this.operation = operation;
+	    this.dashboardUrl = dashboardUrl;
+	    this.async = isAsync;
     }
 
     public String getOperation() {


### PR DESCRIPTION
This PR holds changes to return a 202 response with the same information like the initial service provisioning response, when a provisioning request is done while provisioning is still in progress.

For convenience some helper methods were added to the JobProgress class to identify the current operation and its state.

Furthermore added docs to help explain what the operation field of JobProgress describes, because it is NOT used for returning the operation string to the platform.