### PR TITLE
Fix the response for identical provision requests

### DIFF
--- a/core/src/main/java/de/evoila/cf/broker/controller/BaseController.java
+++ b/core/src/main/java/de/evoila/cf/broker/controller/BaseController.java
@@ -3,6 +3,7 @@ package de.evoila.cf.broker.controller;
 import de.evoila.cf.broker.exception.*;
 import de.evoila.cf.broker.model.ResponseMessage;
 import de.evoila.cf.broker.model.ServiceBrokerErrorResponse;
+import de.evoila.cf.broker.util.EmptyRestResponse;
 import org.everit.json.schema.ValidationException;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -20,6 +21,8 @@ public abstract class BaseController {
     protected ResponseEntity processErrorResponse(HttpStatus status) {
         return new ResponseEntity(status);
     }
+
+    protected ResponseEntity processEmptyErrorResponse(HttpStatus status) { return new ResponseEntity<String>(EmptyRestResponse.BODY, status);}
 
     protected ResponseEntity processErrorResponse(String message, HttpStatus status) {
         return new ResponseEntity(new ResponseMessage(message), status);
@@ -62,6 +65,8 @@ public abstract class BaseController {
 
     @ExceptionHandler(ServiceInstanceExistsException.class)
     public ResponseEntity<ResponseMessage> handleException(ServiceInstanceExistsException ex) {
+        if (ex.isIdenticalInstance())
+            return processEmptyErrorResponse(HttpStatus.OK);
         return processErrorResponse(ex.getMessage(), HttpStatus.CONFLICT);
     }
 

--- a/core/src/main/java/de/evoila/cf/broker/util/ServiceInstanceUtils.java
+++ b/core/src/main/java/de/evoila/cf/broker/util/ServiceInstanceUtils.java
@@ -1,5 +1,7 @@
 package de.evoila.cf.broker.util;
 
+import de.evoila.cf.broker.model.ServiceInstance;
+import de.evoila.cf.broker.model.ServiceInstanceRequest;
 import de.evoila.cf.broker.model.catalog.ServerAddress;
 import org.springframework.util.StringUtils;
 
@@ -95,5 +97,19 @@ public class ServiceInstanceUtils {
 
     public static ServerAddress serverAddress(String name, String host, int port) {
         return new ServerAddress(name, host, port);
+    }
+
+    public static boolean wouldCreateIdenticalInstance(String serviceInstanceId, ServiceInstanceRequest request, ServiceInstance serviceInstance) {
+        if (StringUtils.isEmpty(serviceInstanceId) || request == null || serviceInstance == null) return true;
+        if (request.getContext() == null ^ serviceInstance.getContext() == null) return false;
+        if (request.getParameters() == null ^ serviceInstance.getParameters() == null) return false;
+
+        return serviceInstanceId.equals(serviceInstance.getId())
+                && request.getServiceDefinitionId().equals(serviceInstance.getServiceDefinitionId())
+                && request.getPlanId().equals(serviceInstance.getPlanId())
+                && request.getOrganizationGuid().equals(serviceInstance.getOrganizationGuid())
+                && request.getSpaceGuid().equals(serviceInstance.getSpaceGuid())
+                && request.getContext().equals(serviceInstance.getContext())
+                && request.getParameters().equals(request.getParameters());
     }
 }

--- a/core/src/main/java/de/evoila/cf/broker/util/ServiceInstanceUtils.java
+++ b/core/src/main/java/de/evoila/cf/broker/util/ServiceInstanceUtils.java
@@ -123,7 +123,7 @@ public class ServiceInstanceUtils {
                 && request.getOrganizationGuid().equals(serviceInstance.getOrganizationGuid())
                 && request.getSpaceGuid().equals(serviceInstance.getSpaceGuid())
                 && request.getContext().equals(serviceInstance.getContext())
-                && request.getParameters().equals(request.getParameters());
+                && request.getParameters().equals(serviceInstance.getParameters());
     }
 
      /**

--- a/core/src/main/java/de/evoila/cf/broker/util/ServiceInstanceUtils.java
+++ b/core/src/main/java/de/evoila/cf/broker/util/ServiceInstanceUtils.java
@@ -98,7 +98,19 @@ public class ServiceInstanceUtils {
     public static ServerAddress serverAddress(String name, String host, int port) {
         return new ServerAddress(name, host, port);
     }
-
+    
+    /**
+     * Checks whether a service creation with the fiven ServiceInstanceRequest would provision an identical service instance.
+     *
+     * This method heavily relies on the {@linkplain Object#equals(Object)} method to check for equality
+     * and resulting non-effective changes to a field. So it is mandatory for all objects contained in
+     * {@linkplain ServiceInstance#getParameters()} to have an overwritten equals method or can ensure equality by identity.
+     *
+     * @param serviceInstanceId the service instance object to compare with the provision request
+     * @param request the provision request object to compare with the service instance
+     * @param serviceInstance the service instance object to compare with the provision request
+     * @return true if provisioning would create an identical instance and false if it would not
+     */
     public static boolean wouldCreateIdenticalInstance(String serviceInstanceId, ServiceInstanceRequest request, ServiceInstance serviceInstance) {
         if (StringUtils.isEmpty(serviceInstanceId) || request == null || serviceInstance == null) return true;
         if (request.getContext() == null ^ serviceInstance.getContext() == null) return false;

--- a/model/src/main/java/de/evoila/cf/broker/exception/ServiceInstanceExistsException.java
+++ b/model/src/main/java/de/evoila/cf/broker/exception/ServiceInstanceExistsException.java
@@ -7,20 +7,36 @@ package de.evoila.cf.broker.exception;
  */
 public class ServiceInstanceExistsException extends Exception {
 
-	private static final long serialVersionUID = -914571358227517785L;
-
 	private String instanceId;
 
 	private String serviceId;
 
+	/**
+	 * Whether this exception was thrown because the provision request would create an identical instance.
+	 */
+	private boolean identicalInstance;
+
 	public ServiceInstanceExistsException(String instanceId, String serviceId) {
+		this(instanceId, serviceId, false);
+	}
+
+	public ServiceInstanceExistsException(String instanceId, String serviceId, boolean identicalInstance) {
 		this.instanceId = instanceId;
 		this.serviceId = serviceId;
+		this.identicalInstance = identicalInstance;
 	}
 
 	@Override
 	public String getMessage() {
 		return "ServiceInstance with the given id already exists: ServiceInstance.id = " + instanceId
 				+ ", Service.id = " + serviceId;
+	}
+
+	/**
+	 * Returns whether this exception was thrown because the provision request would create an identical instance.
+	 * @return true if an identical service instance would have been created and false otherwise
+	 */
+	public boolean isIdenticalInstance() {
+		return identicalInstance;
 	}
 }


### PR DESCRIPTION
**Note: This PR should be reviewed after PR https://github.com/evoila/osb-core/pull/48**

This PR holds changes for returning a 200 when a provision request would trigger a creation of an identical service instance instead of returning 409.

- a Utils method was added to check if a request would create an identical instance
- altered ServiceInstanceExistsException to hold an identical flag
- change exception handling of the base controller to distinguish between the identical and conflict case
 