### PR TITLE
Feat/service instance context update

### DIFF
--- a/core/src/main/java/de/evoila/cf/broker/controller/core/ServiceInstanceController.java
+++ b/core/src/main/java/de/evoila/cf/broker/controller/core/ServiceInstanceController.java
@@ -131,6 +131,18 @@ public class ServiceInstanceController extends BaseController {
             if (serviceInstance == null) {
                 throw new ServiceInstanceNotFoundException(serviceInstanceId);
             }
+
+            if (request.isContextUpdate()) {
+                if (serviceInstance.isAllowContextUpdates()) {
+                    serviceInstanceOperationResponse = deploymentService.updateServiceInstanceContext(serviceInstanceId, request);
+                    return new ResponseEntity(serviceInstanceOperationResponse, HttpStatus.OK);
+                } else {
+                    return new ResponseEntity(new ServiceBrokerErrorResponse("ContextUpdateNotAllowed",
+                            "It is not allowed to alter the context of the requested service instance"),
+                            HttpStatus.UNPROCESSABLE_ENTITY);
+                }
+            }
+
             if (!ServiceInstanceUtils.isEffectivelyUpdating(serviceInstance, request)) {
                 log.info("Update would have not effective changes.");
                 return new ResponseEntity(EmptyRestResponse.BODY, HttpStatus.OK);

--- a/core/src/main/java/de/evoila/cf/broker/service/DeploymentService.java
+++ b/core/src/main/java/de/evoila/cf/broker/service/DeploymentService.java
@@ -19,7 +19,10 @@ public interface DeploymentService {
     ServiceInstanceOperationResponse updateServiceInstance(String serviceInstanceId, ServiceInstanceUpdateRequest serviceInstanceUpdateRequest)
             throws ServiceBrokerException, ServiceInstanceDoesNotExistException, ServiceDefinitionDoesNotExistException;
 
-    ServiceInstanceOperationResponse deleteServiceInstance(String instanceId) throws ServiceBrokerException, ServiceDefinitionDoesNotExistException,
+	ServiceInstanceOperationResponse updateServiceInstanceContext(String serviceInstanceId, ServiceInstanceUpdateRequest serviceInstanceUpdateRequest)
+			throws ServiceBrokerException, ServiceInstanceDoesNotExistException, ServiceDefinitionDoesNotExistException;
+
+	ServiceInstanceOperationResponse deleteServiceInstance(String instanceId) throws ServiceBrokerException, ServiceDefinitionDoesNotExistException,
             ServiceInstanceDoesNotExistException;
 
 	ServiceInstance fetchServiceInstance(String instanceId) throws UnsupportedOperationException, ServiceBrokerException,

--- a/core/src/main/java/de/evoila/cf/broker/service/impl/DeploymentServiceImpl.java
+++ b/core/src/main/java/de/evoila/cf/broker/service/impl/DeploymentServiceImpl.java
@@ -168,6 +168,21 @@ public class DeploymentServiceImpl implements DeploymentService {
     }
 
     @Override
+    public ServiceInstanceOperationResponse updateServiceInstanceContext(String serviceInstanceId,
+                                                                         ServiceInstanceUpdateRequest serviceInstanceUpdateRequest)
+            throws ServiceBrokerException, ServiceInstanceDoesNotExistException, ServiceDefinitionDoesNotExistException {
+
+        ServiceInstance serviceInstance = serviceInstanceRepository.getServiceInstance(serviceInstanceId);
+        if (serviceInstance == null) {
+            throw new ServiceInstanceDoesNotExistException(serviceInstanceId);
+        }
+        serviceInstance.setContext(serviceInstanceUpdateRequest.getContext());
+        serviceInstanceRepository.updateServiceInstance(serviceInstance);
+
+        return new ServiceInstanceOperationResponse();
+    }
+
+    @Override
     public ServiceInstanceOperationResponse deleteServiceInstance(String instanceId)
             throws ServiceBrokerException, ServiceInstanceDoesNotExistException, ServiceDefinitionDoesNotExistException {
         ServiceInstance serviceInstance = serviceInstanceRepository.getServiceInstance(instanceId);

--- a/core/src/main/java/de/evoila/cf/broker/service/impl/DeploymentServiceImpl.java
+++ b/core/src/main/java/de/evoila/cf/broker/service/impl/DeploymentServiceImpl.java
@@ -5,12 +5,14 @@ package de.evoila.cf.broker.service.impl;
 
 import de.evoila.cf.broker.exception.*;
 import de.evoila.cf.broker.model.*;
+import de.evoila.cf.broker.model.catalog.ServiceDefinition;
 import de.evoila.cf.broker.model.catalog.plan.Plan;
 import de.evoila.cf.broker.repository.JobRepository;
 import de.evoila.cf.broker.repository.PlatformRepository;
 import de.evoila.cf.broker.repository.ServiceDefinitionRepository;
 import de.evoila.cf.broker.repository.ServiceInstanceRepository;
 import de.evoila.cf.broker.service.AsyncDeploymentService;
+import de.evoila.cf.broker.service.CatalogService;
 import de.evoila.cf.broker.service.DeploymentService;
 import de.evoila.cf.broker.service.PlatformService;
 import de.evoila.cf.broker.util.ParameterValidator;
@@ -40,18 +42,21 @@ public class DeploymentServiceImpl implements DeploymentService {
 
     private JobRepository jobRepository;
 
+    private CatalogService catalogService;
+
     private AsyncDeploymentService asyncDeploymentService;
 
     private RandomString randomString = new RandomString();
 
     public DeploymentServiceImpl(PlatformRepository platformRepository, ServiceDefinitionRepository serviceDefinitionRepository,
                                  ServiceInstanceRepository serviceInstanceRepository,
-                                 JobRepository jobRepository, AsyncDeploymentService asyncDeploymentService) {
+                                 JobRepository jobRepository, AsyncDeploymentService asyncDeploymentService, CatalogService catalogService) {
         this.platformRepository = platformRepository;
         this.serviceDefinitionRepository = serviceDefinitionRepository;
         this.serviceInstanceRepository = serviceInstanceRepository;
         this.jobRepository = jobRepository;
         this.asyncDeploymentService = asyncDeploymentService;
+        this.catalogService = catalogService;
     }
 
     @Override
@@ -98,8 +103,10 @@ public class DeploymentServiceImpl implements DeploymentService {
             throw new ServiceInstanceExistsException(serviceInstanceId, request.getServiceDefinitionId());
         }
 
+        ServiceDefinition serviceDefinition = catalogService.getServiceDefinition(request.getServiceDefinitionId());
         ServiceInstance serviceInstance = new ServiceInstance(serviceInstanceId, request.getServiceDefinitionId(),
                 request.getPlanId(), request.getOrganizationGuid(), request.getSpaceGuid(), request.getParameters(), request.getContext());
+        serviceInstance.setAllowContextUpdates(serviceDefinition.isAllowContextUpdates());
 
         Plan plan = serviceDefinitionRepository.getPlan(request.getPlanId());
 

--- a/core/src/main/java/de/evoila/cf/broker/service/impl/DeploymentServiceImpl.java
+++ b/core/src/main/java/de/evoila/cf/broker/service/impl/DeploymentServiceImpl.java
@@ -132,12 +132,7 @@ public class DeploymentServiceImpl implements DeploymentService {
     @Override
     public ServiceInstanceOperationResponse updateServiceInstance(String serviceInstanceId, ServiceInstanceUpdateRequest request) throws ServiceBrokerException,
             ServiceInstanceDoesNotExistException, ServiceDefinitionDoesNotExistException, ValidationException {
-
         ServiceInstance serviceInstance = serviceInstanceRepository.getServiceInstance(serviceInstanceId);
-        if (serviceInstance == null) {
-            throw new ServiceInstanceDoesNotExistException(serviceInstanceId);
-        }
-
         Plan plan = serviceDefinitionRepository.getPlan(request.getPlanId());
 
         if (request.getParameters() != null) {
@@ -171,11 +166,7 @@ public class DeploymentServiceImpl implements DeploymentService {
     public ServiceInstanceOperationResponse updateServiceInstanceContext(String serviceInstanceId,
                                                                          ServiceInstanceUpdateRequest serviceInstanceUpdateRequest)
             throws ServiceBrokerException, ServiceInstanceDoesNotExistException, ServiceDefinitionDoesNotExistException {
-
         ServiceInstance serviceInstance = serviceInstanceRepository.getServiceInstance(serviceInstanceId);
-        if (serviceInstance == null) {
-            throw new ServiceInstanceDoesNotExistException(serviceInstanceId);
-        }
         serviceInstance.setContext(serviceInstanceUpdateRequest.getContext());
         serviceInstanceRepository.updateServiceInstance(serviceInstance);
 

--- a/model/src/main/java/de/evoila/cf/broker/model/ServiceInstance.java
+++ b/model/src/main/java/de/evoila/cf/broker/model/ServiceInstance.java
@@ -73,7 +73,7 @@ public class ServiceInstance implements BaseEntity<String> {
     private String usergroup;
 
     @JsonSerialize
-	@JsonProperty("allow_context_update")
+	@JsonProperty("allow_context_updates")
     private boolean allowContextUpdates;
 
 	@SuppressWarnings("unused")

--- a/model/src/main/java/de/evoila/cf/broker/model/ServiceInstance.java
+++ b/model/src/main/java/de/evoila/cf/broker/model/ServiceInstance.java
@@ -72,6 +72,10 @@ public class ServiceInstance implements BaseEntity<String> {
     @JsonIgnore
     private String usergroup;
 
+    @JsonSerialize
+	@JsonProperty("allow_context_update")
+    private boolean allowContextUpdates;
+
 	@SuppressWarnings("unused")
 	private ServiceInstance() {}
 
@@ -230,4 +234,11 @@ public class ServiceInstance implements BaseEntity<String> {
 
 	public void setFloatingIpId(String floatingIpId) { this.floatingIpId = floatingIpId; }
 
+	public boolean isAllowContextUpdates() {
+		return allowContextUpdates;
+	}
+
+	public void setAllowContextUpdates(boolean allowContextUpdates) {
+		this.allowContextUpdates = allowContextUpdates;
+	}
 }

--- a/model/src/main/java/de/evoila/cf/broker/model/ServiceInstancePreviousValues.java
+++ b/model/src/main/java/de/evoila/cf/broker/model/ServiceInstancePreviousValues.java
@@ -2,6 +2,7 @@ package de.evoila.cf.broker.model;
 
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.databind.annotation.JsonSerialize;
+import de.evoila.cf.broker.model.catalog.MaintenanceInfo;
 
 import javax.validation.constraints.NotEmpty;
 
@@ -28,14 +29,19 @@ public class ServiceInstancePreviousValues {
     @JsonProperty("space_guid")
     private String spaceGuid;
 
+    @JsonSerialize
+    @JsonProperty("maintenance_info")
+    private MaintenanceInfo maintenanceInfo;
+
+    @Deprecated
     public String getServiceId() {
         return serviceId;
     }
 
+    @Deprecated
     public void setServiceId(String serviceId) {
         this.serviceId = serviceId;
     }
-
     public String getPlanId() {
         return planId;
     }
@@ -44,19 +50,31 @@ public class ServiceInstancePreviousValues {
         this.planId = planId;
     }
 
+    @Deprecated
     public String getOrganizationGuid() {
         return organizationGuid;
     }
 
+    @Deprecated
     public void setOrganizationGuid(String organizationGuid) {
         this.organizationGuid = organizationGuid;
     }
 
+    @Deprecated
     public String getSpaceGuid() {
         return spaceGuid;
     }
 
+    @Deprecated
     public void setSpaceGuid(String spaceGuid) {
         this.spaceGuid = spaceGuid;
+    }
+
+    public MaintenanceInfo getMaintenanceInfo() {
+        return maintenanceInfo;
+    }
+
+    public void setMaintenanceInfo(MaintenanceInfo maintenanceInfo) {
+        this.maintenanceInfo = maintenanceInfo;
     }
 }

--- a/model/src/main/java/de/evoila/cf/broker/model/ServiceInstanceUpdateRequest.java
+++ b/model/src/main/java/de/evoila/cf/broker/model/ServiceInstanceUpdateRequest.java
@@ -32,4 +32,8 @@ public class ServiceInstanceUpdateRequest extends BaseServiceInstanceRequest {
     public void setPreviousValues(ServiceInstancePreviousValues previousValues) {
         this.previousValues = previousValues;
     }
+
+    public Boolean isContextUpdate() {
+	    return (parameters == null || parameters.isEmpty()) && (context != null && !context.isEmpty());
+    }
 }

--- a/model/src/main/java/de/evoila/cf/broker/model/catalog/ServiceDefinition.java
+++ b/model/src/main/java/de/evoila/cf/broker/model/catalog/ServiceDefinition.java
@@ -2,6 +2,7 @@ package de.evoila.cf.broker.model.catalog;
 
 import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.databind.annotation.JsonSerialize;
 import de.evoila.cf.broker.model.DashboardClient;
 import de.evoila.cf.broker.model.catalog.plan.Plan;
 
@@ -47,6 +48,10 @@ public class ServiceDefinition {
 
     @JsonProperty("plan_updateable") // misspelling of attribute kept, do not change it
     private boolean updateable;
+
+    @JsonSerialize
+    @JsonProperty("allow_context_updates")
+    private boolean allowContextUpdates;
 
     public ServiceDefinition() {
     }
@@ -186,5 +191,13 @@ public class ServiceDefinition {
 
     public void setInstancesRetrievable(boolean instancesRetrievable) {
         this.instancesRetrievable = instancesRetrievable;
+    }
+
+    public boolean isAllowContextUpdates() {
+        return allowContextUpdates;
+    }
+
+    public void setAllowContextUpdates(boolean allowContextUpdates) {
+        this.allowContextUpdates = allowContextUpdates;
     }
 }


### PR DESCRIPTION
Enable Platforms to send an update request for a Service Instance containing only contextual data (no changes to the Service Plan or parameters). This MAY be used by Platforms to let Service Brokers know when contextual information for a Service Instance has changed (i.e. instance_name in the Cloud Foundry Context Object. To enable support for Platforms to send an update request for a Service Instance containing only contextual data, a Service Broker MUST declare support by including "allow_context_updates": true in its catalog endpoint.

previous_values has according to spec deprecated fields.
They get are marked as such in the class.