### PR TITLE
Fixing: Getting a 422 error when fetching a binding with a non-existing service instance

### DIFF
--- a/core/src/main/java/de/evoila/cf/broker/controller/BaseController.java
+++ b/core/src/main/java/de/evoila/cf/broker/controller/BaseController.java
@@ -77,7 +77,7 @@ public abstract class BaseController {
 
     @ExceptionHandler(ServiceInstanceNotFoundException.class)
     public ResponseEntity<ResponseMessage> handleException(ServiceInstanceNotFoundException ex) {
-        return processErrorResponse(HttpStatus.NOT_FOUND);
+        return processErrorResponse(ex.getError(), ex.getMessage(), HttpStatus.NOT_FOUND);
     }
 
     @ExceptionHandler(ServiceInstanceBindingExistsException.class)

--- a/core/src/main/java/de/evoila/cf/broker/controller/core/ServiceInstanceBindingController.java
+++ b/core/src/main/java/de/evoila/cf/broker/controller/core/ServiceInstanceBindingController.java
@@ -147,17 +147,14 @@ public class ServiceInstanceBindingController extends BaseController {
             @PathVariable("bindingId") String bindingId,
             @RequestHeader(value = "X-Broker-API-Originating-Identity", required = false) String originatingIdentity,
             @RequestHeader(value = "X-Broker-API-Request-Identity", required = false) String requestIdentity) throws
-            ServiceInstanceBindingNotFoundException, ServiceBrokerException {
+            ServiceInstanceBindingNotFoundException, ServiceBrokerException, ServiceInstanceNotFoundException {
 
         ServiceInstance serviceInstance;
         try {
             serviceInstance = bindingService.getServiceInstance(instanceId);
         } catch (ServiceInstanceDoesNotExistException ex) {
-            // Has to return different status code instead of 404, because 404 is reserved for when the binding does not exist
-            // 400 was chosen, because the id of the service instance is defined as "MUST be the ID of a previously provisioned Service Instance"
-            return processErrorResponse("ServiceInstanceNotFound",
-                    "No service instance was found for the given id. This could be caused by a desynchronization between broker and platform.",
-                    HttpStatus.BAD_REQUEST);
+            log.error("Tried to fetch a binding without a existing service instance. InstanceId : " + instanceId, ex);
+            throw new ServiceInstanceNotFoundException(instanceId);
         }
 
         if (!(catalogService.getServiceDefinition(serviceInstance.getServiceDefinitionId()).isBindingsRetrievable())) {

--- a/core/src/main/java/de/evoila/cf/broker/controller/core/ServiceInstanceBindingController.java
+++ b/core/src/main/java/de/evoila/cf/broker/controller/core/ServiceInstanceBindingController.java
@@ -147,16 +147,9 @@ public class ServiceInstanceBindingController extends BaseController {
             @PathVariable("bindingId") String bindingId,
             @RequestHeader(value = "X-Broker-API-Originating-Identity", required = false) String originatingIdentity,
             @RequestHeader(value = "X-Broker-API-Request-Identity", required = false) String requestIdentity) throws
-            ServiceInstanceBindingNotFoundException, ServiceBrokerException, ServiceInstanceNotFoundException, ServiceDefinitionDoesNotExistException {
+            ServiceInstanceBindingNotFoundException, ServiceBrokerException, ServiceDefinitionDoesNotExistException, ServiceInstanceDoesNotExistException {
 
-
-        ServiceInstance serviceInstance;
-        try {
-            serviceInstance = bindingService.getServiceInstance(instanceId);
-        } catch (ServiceInstanceDoesNotExistException ex) {
-            log.error("Tried to fetch a binding without a existing service instance. InstanceId : " + instanceId, ex);
-            throw new ServiceInstanceNotFoundException(instanceId);
-        }
+        ServiceInstance serviceInstance = bindingService.getServiceInstance(instanceId);
 
         if (!(catalogService.getServiceDefinition(serviceInstance.getServiceDefinitionId()).isBindingsRetrievable())) {
             throw new ServiceInstanceBindingNotRetrievableException("The Service Binding could not be retrievable. You should not attempt to call this endpoint");
@@ -171,8 +164,8 @@ public class ServiceInstanceBindingController extends BaseController {
      * Over writing the ExceptionHandler in this controller, as 404 is reserved for service-bindings. Using 400 instead.
      * Not using try catch, to unify this behaviour.
      */
-    @ExceptionHandler(ServiceInstanceNotFoundException.class)
-    public ResponseEntity<ResponseMessage> handleException(ServiceInstanceNotFoundException ex) {
+    @ExceptionHandler(ServiceInstanceDoesNotExistException.class)
+    public ResponseEntity<ResponseMessage> handleException(ServiceInstanceDoesNotExistException ex) {
         return processErrorResponse(ex.getError(), ex.getMessage(), HttpStatus.BAD_REQUEST);
     }
 }

--- a/core/src/main/java/de/evoila/cf/broker/controller/core/ServiceInstanceBindingController.java
+++ b/core/src/main/java/de/evoila/cf/broker/controller/core/ServiceInstanceBindingController.java
@@ -167,4 +167,12 @@ public class ServiceInstanceBindingController extends BaseController {
         return new ResponseEntity<>(response, HttpStatus.OK);
     }
 
+    /*
+     * Over writing the ExceptionHandler in this controller, as 404 is reserved for service-bindings. Using 400 instead.
+     * Not using try catch, to unify this behaviour.
+     */
+    @ExceptionHandler(ServiceInstanceNotFoundException.class)
+    public ResponseEntity<ResponseMessage> handleException(ServiceInstanceNotFoundException ex) {
+        return processErrorResponse(ex.getError(), ex.getMessage(), HttpStatus.BAD_REQUEST);
+    }
 }

--- a/model/src/main/java/de/evoila/cf/broker/exception/ServiceInstanceDoesNotExistException.java
+++ b/model/src/main/java/de/evoila/cf/broker/exception/ServiceInstanceDoesNotExistException.java
@@ -9,11 +9,9 @@ package de.evoila.cf.broker.exception;
 public class ServiceInstanceDoesNotExistException extends Exception {
 	
 	private static final long serialVersionUID = -1879753092397657116L;
-	
+
 	private String serviceInstanceId;
 
-	private String error = "ServiceInstanceDoesNotExistException";
-	
 	public ServiceInstanceDoesNotExistException(String serviceInstanceId) {
 		this.serviceInstanceId = serviceInstanceId;
 	}
@@ -23,10 +21,6 @@ public class ServiceInstanceDoesNotExistException extends Exception {
 	}
 
 	public String getError() {
-		return error;
-	}
-
-	public void setError(String error) {
-		this.error = error;
+		return "ServiceInstanceDoesNotExistException";
 	}
 }

--- a/model/src/main/java/de/evoila/cf/broker/exception/ServiceInstanceDoesNotExistException.java
+++ b/model/src/main/java/de/evoila/cf/broker/exception/ServiceInstanceDoesNotExistException.java
@@ -11,6 +11,8 @@ public class ServiceInstanceDoesNotExistException extends Exception {
 	private static final long serialVersionUID = -1879753092397657116L;
 	
 	private String serviceInstanceId;
+
+	private String error = "ServiceInstanceDoesNotExistException";
 	
 	public ServiceInstanceDoesNotExistException(String serviceInstanceId) {
 		this.serviceInstanceId = serviceInstanceId;
@@ -19,5 +21,12 @@ public class ServiceInstanceDoesNotExistException extends Exception {
 	public String getMessage() {
 		return "ServiceInstance does not exist: id = " + serviceInstanceId;
 	}
-	
+
+	public String getError() {
+		return error;
+	}
+
+	public void setError(String error) {
+		this.error = error;
+	}
 }

--- a/model/src/main/java/de/evoila/cf/broker/exception/ServiceInstanceNotFoundException.java
+++ b/model/src/main/java/de/evoila/cf/broker/exception/ServiceInstanceNotFoundException.java
@@ -10,6 +10,10 @@ public class ServiceInstanceNotFoundException extends Exception {
 
     private static final long serialVersionUID = -5984853893472349837L;
 
+    public String getError() {
+        return "ServiceInstanceNotFound";
+    }
+
     public ServiceInstanceNotFoundException() {
         this("");
     }


### PR DESCRIPTION
Example error 
{
    "error": "ServiceInstanceNotFound",
    "description": "Service Instance 5f301293-affb-4970-9c79-5f09da4494af does not exists or an operation for this Instance is still in progress."
}