### PR TITLE
Fix/create job progress for synchronous bindings

### DIFF
--- a/core/src/main/java/de/evoila/cf/broker/service/impl/BindingServiceImpl.java
+++ b/core/src/main/java/de/evoila/cf/broker/service/impl/BindingServiceImpl.java
@@ -80,7 +80,8 @@ public abstract class BindingServiceImpl implements BindingService {
             if (platformService.isSyncPossibleOnBind()) {
                 baseServiceInstanceBindingResponse = syncCreateBinding(bindingId, serviceInstance,
 						serviceInstanceBindingRequest, plan);
-                jobRepository.saveJobProgress(randomString.nextString(), bindingId, JobProgress.SUCCESS, "Synchronous binding.", operationId);
+                jobRepository.saveJobProgress(randomString.nextString(), bindingId, JobProgress.SUCCESS,
+						"Successfully created a synchronous binding.", operationId);
             } else {
                 bindingRepository.addInternalBinding(new ServiceInstanceBinding(bindingId, instanceId, null));
 
@@ -96,6 +97,8 @@ public abstract class BindingServiceImpl implements BindingService {
 			} else {
 				baseServiceInstanceBindingResponse = syncCreateBinding(bindingId, serviceInstance,
 						serviceInstanceBindingRequest, plan);
+				jobRepository.saveJobProgress(randomString.nextString(), bindingId, JobProgress.SUCCESS,
+						"Successfully created a synchronous binding.", operationId);
 			}
 		}
 		return baseServiceInstanceBindingResponse;

--- a/core/src/main/java/de/evoila/cf/broker/service/impl/BindingServiceImpl.java
+++ b/core/src/main/java/de/evoila/cf/broker/service/impl/BindingServiceImpl.java
@@ -167,7 +167,6 @@ public abstract class BindingServiceImpl implements BindingService {
 			throws  ServiceInstanceBindingDoesNotExistsException {
 		JobProgress progress = asyncBindingService.getProgressByReferenceId(referenceId);
 
-		//Progress is never null
 		if (progress == null || !bindingRepository.containsInternalBindingId(referenceId)) {
 			throw new ServiceInstanceBindingDoesNotExistsException(referenceId);
 		}


### PR DESCRIPTION
When creating a synchronous binding a Job Progress object is saved, to 
avoid that error messages get returned, if everything is fine.