### PR TITLE
Fix/osb 1105 return 200 when identical binding

### DIFF
--- a/core/src/main/java/de/evoila/cf/broker/controller/BaseController.java
+++ b/core/src/main/java/de/evoila/cf/broker/controller/BaseController.java
@@ -22,7 +22,9 @@ public abstract class BaseController {
         return new ResponseEntity(status);
     }
 
-    protected ResponseEntity processEmptyErrorResponse(HttpStatus status) { return new ResponseEntity<String>(EmptyRestResponse.BODY, status);}
+    protected ResponseEntity processEmptyErrorResponse(HttpStatus status) {
+        return new ResponseEntity<String>(EmptyRestResponse.BODY, status);
+    }
 
     protected ResponseEntity processErrorResponse(String message, HttpStatus status) {
         return new ResponseEntity(new ResponseMessage(message), status);
@@ -82,6 +84,9 @@ public abstract class BaseController {
 
     @ExceptionHandler(ServiceInstanceBindingExistsException.class)
     public ResponseEntity<ResponseMessage> handleException(ServiceInstanceBindingExistsException ex) {
+        if (ex.isIdenticalBinding()) {
+            return processEmptyErrorResponse(HttpStatus.OK);
+        }
         return processErrorResponse(HttpStatus.CONFLICT);
     }
 

--- a/core/src/main/java/de/evoila/cf/broker/service/impl/BindingServiceImpl.java
+++ b/core/src/main/java/de/evoila/cf/broker/service/impl/BindingServiceImpl.java
@@ -245,9 +245,12 @@ public abstract class BindingServiceImpl implements BindingService {
 		return serviceInstance;
 	}
 
-	protected ServiceInstanceBinding bindService(String bindingId, ServiceInstanceBindingRequest serviceInstanceBindingRequest,
-												 ServiceInstance serviceInstance, Plan plan) throws ServiceBrokerException, InvalidParametersException, PlatformException {
-		Map<String, Object> credentials = createCredentials(bindingId, serviceInstanceBindingRequest, serviceInstance, plan, null);
+    protected ServiceInstanceBinding bindService(String bindingId, ServiceInstanceBindingRequest serviceInstanceBindingRequest,
+                                                 ServiceInstance serviceInstance, Plan plan) throws ServiceBrokerException, InvalidParametersException, PlatformException {
+        Map<String, Object> credentials = createCredentials(bindingId, serviceInstanceBindingRequest, serviceInstance, plan, null);
+        String appGuid = getAppGuidFromBindingRequest(serviceInstanceBindingRequest);
+        ServiceInstanceBinding binding = new ServiceInstanceBinding(bindingId, serviceInstance.getId(), credentials);
+        binding.setAppGuid(appGuid);
 
 		return new ServiceInstanceBinding(bindingId, serviceInstance.getId(), credentials);
 	}
@@ -281,5 +284,12 @@ public abstract class BindingServiceImpl implements BindingService {
 
 	public ServiceInstance getServiceInstance(String instanceId) throws ServiceInstanceDoesNotExistException {
 		return serviceInstanceRepository.getServiceInstance(instanceId);
+	}
+	private String getAppGuidFromBindingRequest(ServiceInstanceBindingRequest request) {
+		String appGuid = request.getAppGuid();
+		if (request.getBindResource() != null && request.getBindResource().getAppGuid() != null) {
+			appGuid = request.getBindResource().getAppGuid();
+		}
+		return appGuid;
 	}
 }

--- a/core/src/main/java/de/evoila/cf/broker/service/impl/BindingServiceImpl.java
+++ b/core/src/main/java/de/evoila/cf/broker/service/impl/BindingServiceImpl.java
@@ -18,6 +18,7 @@ import org.springframework.util.StringUtils;
 
 import java.util.Map;
 import java.util.NoSuchElementException;
+import java.util.Objects;
 
 /**
  * @author Johannes Hiemer, Marco Di Martino.
@@ -62,7 +63,7 @@ public abstract class BindingServiceImpl implements BindingService {
 			ServiceBrokerException, ServiceDefinitionDoesNotExistException, ServiceInstanceDoesNotExistException,
 			InvalidParametersException, AsyncRequiredException, ValidationException, PlatformException  {
 
-		validateBindingNotExists(bindingId, instanceId);
+		validateBindingNotExists(serviceInstanceBindingRequest, bindingId, instanceId);
 
 		ServiceInstance serviceInstance = serviceInstanceRepository.getServiceInstance(instanceId);
 
@@ -262,8 +263,8 @@ public abstract class BindingServiceImpl implements BindingService {
                                                              ServiceInstance serviceInstance, Plan plan,
                                                              ServerAddress serverAddress) throws ServiceBrokerException, InvalidParametersException, PlatformException;
 
-	protected void validateBindingNotExists(String bindingId, String instanceId)
-			throws ServiceInstanceBindingExistsException {
+    protected void validateBindingNotExists(ServiceInstanceBindingRequest serviceInstanceBindingRequest, String bindingId, String instanceId)
+            throws ServiceInstanceBindingExistsException, ServiceInstanceDoesNotExistException {
 
 		if (bindingRepository.containsInternalBindingId(bindingId)) {
 			boolean bindCreation;
@@ -276,20 +277,58 @@ public abstract class BindingServiceImpl implements BindingService {
 			} catch (NoSuchElementException e) {
 				return;
 			}
-			if (bindCreation && !isBindingInProgress)
-				throw new ServiceInstanceBindingExistsException(bindingId, instanceId);
-		}
+            if (bindCreation && !isBindingInProgress) {
+                ServiceInstanceBinding serviceInstanceBinding = bindingRepository.findOne(bindingId);
+                boolean identical = wouldCreateIdenticalBinding(serviceInstanceBindingRequest, serviceInstanceBinding);
 
-	}
+                throw new ServiceInstanceBindingExistsException(bindingId, instanceId, identical);
+            }
+        }
+    }
 
 	public ServiceInstance getServiceInstance(String instanceId) throws ServiceInstanceDoesNotExistException {
 		return serviceInstanceRepository.getServiceInstance(instanceId);
 	}
+	private boolean wouldCreateIdenticalBinding(ServiceInstanceBindingRequest request, ServiceInstanceBinding serviceInstanceBinding) throws ServiceInstanceDoesNotExistException {
+		ServiceInstance serviceInstance = serviceInstanceRepository.getServiceInstance(serviceInstanceBinding.getServiceInstanceId());
+		String routeBinding = getRouteBindingFromInstanceBinding(serviceInstanceBinding.getId());
+		String requestRouteBinding = getRouteBindingFromBindingRequest(request);
+		String requestAppGuid = getAppGuidFromBindingRequest(request);
+
+		return Objects.equals(routeBinding, requestRouteBinding) &&
+				Objects.equals(requestAppGuid, serviceInstanceBinding.getAppGuid()) &&
+				Objects.equals(request.getServiceDefinitionId(), serviceInstance.getServiceDefinitionId()) &&
+				Objects.equals(request.getPlanId(), (serviceInstance.getPlanId())) &&
+				Objects.equals(request.getParameters(), serviceInstanceBinding.getParameters());
+	}
+
 	private String getAppGuidFromBindingRequest(ServiceInstanceBindingRequest request) {
 		String appGuid = request.getAppGuid();
 		if (request.getBindResource() != null && request.getBindResource().getAppGuid() != null) {
 			appGuid = request.getBindResource().getAppGuid();
 		}
 		return appGuid;
+	}
+
+	private String getRouteBindingFromBindingRequest(ServiceInstanceBindingRequest request) {
+		BindResource bindResource = request.getBindResource();
+
+		if (bindResource != null) {
+			return bindResource.getRoute();
+		}
+		return null;
+	}
+
+	private String getRouteBindingFromInstanceBinding(String bindingId) {
+		RouteBinding routeBinding;
+		try {
+			routeBinding = routeBindingRepository.findOne(bindingId);
+
+			return routeBinding.getRoute();
+		} catch (NoSuchElementException e) {
+			log.debug("No route for BindingId: " + bindingId + " found", e);
+
+			return null;
+		}
 	}
 }

--- a/core/src/main/java/de/evoila/cf/broker/service/impl/BindingServiceImpl.java
+++ b/core/src/main/java/de/evoila/cf/broker/service/impl/BindingServiceImpl.java
@@ -252,7 +252,7 @@ public abstract class BindingServiceImpl implements BindingService {
         ServiceInstanceBinding binding = new ServiceInstanceBinding(bindingId, serviceInstance.getId(), credentials);
         binding.setAppGuid(appGuid);
 
-		return new ServiceInstanceBinding(bindingId, serviceInstance.getId(), credentials);
+		return binding;
 	}
 
 	protected abstract void unbindService(ServiceInstanceBinding binding, ServiceInstance serviceInstance, Plan plan)

--- a/core/src/main/java/de/evoila/cf/broker/service/impl/BindingServiceImpl.java
+++ b/core/src/main/java/de/evoila/cf/broker/service/impl/BindingServiceImpl.java
@@ -289,6 +289,7 @@ public abstract class BindingServiceImpl implements BindingService {
 	public ServiceInstance getServiceInstance(String instanceId) throws ServiceInstanceDoesNotExistException {
 		return serviceInstanceRepository.getServiceInstance(instanceId);
 	}
+	
 	private boolean wouldCreateIdenticalBinding(ServiceInstanceBindingRequest request, ServiceInstanceBinding serviceInstanceBinding) throws ServiceInstanceDoesNotExistException {
 		ServiceInstance serviceInstance = serviceInstanceRepository.getServiceInstance(serviceInstanceBinding.getServiceInstanceId());
 		String routeBinding = getRouteBindingFromInstanceBinding(serviceInstanceBinding.getId());
@@ -320,15 +321,10 @@ public abstract class BindingServiceImpl implements BindingService {
 	}
 
 	private String getRouteBindingFromInstanceBinding(String bindingId) {
-		RouteBinding routeBinding;
-		try {
-			routeBinding = routeBindingRepository.findOne(bindingId);
+		if (routeBindingRepository.containsRouteBindingId(bindingId)) {
 
-			return routeBinding.getRoute();
-		} catch (NoSuchElementException e) {
-			log.debug("No route for BindingId: " + bindingId + " found", e);
-
-			return null;
+			return routeBindingRepository.findOne(bindingId).getRoute();
 		}
+		return null;
 	}
 }

--- a/model/src/main/java/de/evoila/cf/broker/exception/ServiceInstanceBindingExistsException.java
+++ b/model/src/main/java/de/evoila/cf/broker/exception/ServiceInstanceBindingExistsException.java
@@ -13,14 +13,29 @@ public class ServiceInstanceBindingExistsException extends Exception {
 
 	private String serviceInstanceId;
 
-	public ServiceInstanceBindingExistsException(String bindingId, String serviceInstanceId) {
+
+	/**
+	 * Whether this exception was thrown because the binding request would create an identical binding.
+	 */
+	private boolean identicalBinding;
+
+	public ServiceInstanceBindingExistsException(String bindingId, String serviceInstanceId, Boolean identicalBinding) {
 		this.bindingId = bindingId;
 		this.serviceInstanceId = serviceInstanceId;
+		this.identicalBinding = identicalBinding;
 	}
 
 	@Override
 	public String getMessage() {
 		return "ServiceInstanceBinding already exists: serviceInstanceBinding.id = " + bindingId
 				+ ", serviceInstance.id = " + serviceInstanceId;
+	}
+
+	/**
+	 * Returns whether this exception was thrown because the binding request would create an identical binding.
+	 * @return true if an identical service binding would have been created and false otherwise
+	 */
+	public boolean isIdenticalBinding() {
+		return identicalBinding;
 	}
 }

--- a/model/src/main/java/de/evoila/cf/broker/model/ServiceInstanceBinding.java
+++ b/model/src/main/java/de/evoila/cf/broker/model/ServiceInstanceBinding.java
@@ -25,7 +25,7 @@ public class ServiceInstanceBinding implements BaseEntity<String> {
 
 	private String appGuid;
 
-	private Map<String, Object> parameters;
+    private Map<String, Object> parameters = new HashMap<>();
 
 	private List<VolumeMount> volumeMounts;
 

--- a/model/src/main/java/de/evoila/cf/broker/model/ServiceInstanceBinding.java
+++ b/model/src/main/java/de/evoila/cf/broker/model/ServiceInstanceBinding.java
@@ -25,7 +25,7 @@ public class ServiceInstanceBinding implements BaseEntity<String> {
 
 	private String appGuid;
 
-	private Map<String, String> parameters;
+	private Map<String, Object> parameters;
 
 	private List<VolumeMount> volumeMounts;
 
@@ -71,11 +71,11 @@ public class ServiceInstanceBinding implements BaseEntity<String> {
 
 	public void setAppGuid(String appGuid) { this.appGuid = appGuid; }
 
-	public Map<String, String> getParameters() {
+	public Map<String, Object> getParameters() {
 		return parameters;
 	}
 
-	public void setParameters(Map<String, String> parameters) {
+	public void setParameters(Map<String, Object> parameters) {
 		this.parameters = parameters;
 	}
 


### PR DESCRIPTION
When creating a binding that already got created with the same parameters, 200 now gets returned.
Fixed that provided AppGuids were not saved, when binding on a service instance.