### PR TITLE
fix(ServiceInstanceExistsException): fix return non empty body

### DIFF
--- a/core/src/main/java/de/evoila/cf/broker/controller/BaseController.java
+++ b/core/src/main/java/de/evoila/cf/broker/controller/BaseController.java
@@ -22,7 +22,9 @@ public abstract class BaseController {
         return new ResponseEntity(status);
     }
 
-    protected ResponseEntity processEmptyErrorResponse(HttpStatus status) { return new ResponseEntity<String>(EmptyRestResponse.BODY, status);}
+    protected ResponseEntity processEmptyErrorResponse(HttpStatus status) {
+        return new ResponseEntity<String>(EmptyRestResponse.BODY, status);
+    }
 
     protected ResponseEntity processErrorResponse(String message, HttpStatus status) {
         return new ResponseEntity(new ResponseMessage(message), status);
@@ -64,9 +66,9 @@ public abstract class BaseController {
     }
 
     @ExceptionHandler(ServiceInstanceExistsException.class)
-    public ResponseEntity<ResponseMessage> handleException(ServiceInstanceExistsException ex) {
+    public ResponseEntity handleException(ServiceInstanceExistsException ex) {
         if (ex.isIdenticalInstance())
-            return processEmptyErrorResponse(HttpStatus.OK);
+            return ResponseEntity.ok(ex.getResponse());
         return processErrorResponse(ex.getMessage(), HttpStatus.CONFLICT);
     }
 

--- a/core/src/main/java/de/evoila/cf/broker/controller/core/ServiceInstanceController.java
+++ b/core/src/main/java/de/evoila/cf/broker/controller/core/ServiceInstanceController.java
@@ -78,8 +78,6 @@ public class ServiceInstanceController extends BaseController {
 
         ServiceInstanceOperationResponse response = deploymentService.createServiceInstance(serviceInstanceId, request);
 
-        if (DashboardUtils.hasDashboard(svc))
-            response.setDashboardUrl(DashboardUtils.dashboard(svc, serviceInstanceId));
         log.debug("ServiceInstance Creation Started: " + serviceInstanceId);
 
         if (response.isAsync())

--- a/core/src/main/java/de/evoila/cf/broker/service/impl/DeploymentServiceImpl.java
+++ b/core/src/main/java/de/evoila/cf/broker/service/impl/DeploymentServiceImpl.java
@@ -3,6 +3,7 @@
  */
 package de.evoila.cf.broker.service.impl;
 
+import de.evoila.cf.broker.controller.utils.DashboardUtils;
 import de.evoila.cf.broker.exception.*;
 import de.evoila.cf.broker.model.*;
 import de.evoila.cf.broker.model.catalog.ServiceDefinition;
@@ -110,6 +111,14 @@ public class DeploymentServiceImpl implements DeploymentService {
                 request.getPlanId(), request.getOrganizationGuid(), request.getSpaceGuid(), request.getParameters(), request.getContext());
         serviceInstance.setAllowContextUpdates(serviceDefinition.isAllowContextUpdates());
 
+        ServiceInstanceOperationResponse serviceInstanceOperationResponse = new ServiceInstanceOperationResponse();
+
+        if (DashboardUtils.hasDashboard(serviceDefinition)){
+            String dashboardUrl = DashboardUtils.dashboard(serviceDefinition, serviceInstanceId);
+            serviceInstance.setDashboardUrl(dashboardUrl);
+            serviceInstanceOperationResponse.setDashboardUrl(dashboardUrl);
+        }
+
         Plan plan = serviceDefinitionRepository.getPlan(request.getPlanId());
 
         if (request.getParameters() != null) {
@@ -121,7 +130,6 @@ public class DeploymentServiceImpl implements DeploymentService {
             throw new ServiceBrokerException("Not Platform configured for " + plan.getPlatform());
         }
 
-        ServiceInstanceOperationResponse serviceInstanceOperationResponse = new ServiceInstanceOperationResponse();
         if (platformService.isSyncPossibleOnCreate(plan)) {
             return serviceInstanceOperationResponse;
         } else {

--- a/core/src/main/java/de/evoila/cf/broker/service/impl/DeploymentServiceImpl.java
+++ b/core/src/main/java/de/evoila/cf/broker/service/impl/DeploymentServiceImpl.java
@@ -97,7 +97,9 @@ public class DeploymentServiceImpl implements DeploymentService {
                             serviceInstanceOptional.get().getDashboardUrl(), true);
                 } else if (jobProgress.isSucceeded() && ServiceInstanceUtils.wouldCreateIdenticalInstance(
                         serviceInstanceId, request, serviceInstanceOptional.get())) {
-                    throw new ServiceInstanceExistsException(serviceInstanceId, request.getServiceDefinitionId(), true);
+                    throw new ServiceInstanceExistsException(serviceInstanceId, request.getServiceDefinitionId(), true,
+                            new ServiceInstanceOperationResponse(jobProgress.getId(),
+                                    serviceInstanceOptional.get().getDashboardUrl(), true));
                 }
             }
             throw new ServiceInstanceExistsException(serviceInstanceId, request.getServiceDefinitionId());

--- a/model/src/main/java/de/evoila/cf/broker/exception/ServiceInstanceExistsException.java
+++ b/model/src/main/java/de/evoila/cf/broker/exception/ServiceInstanceExistsException.java
@@ -1,5 +1,7 @@
 package de.evoila.cf.broker.exception;
 
+import de.evoila.cf.broker.model.ServiceInstanceOperationResponse;
+
 /**
  * Thrown when a duplicate service instance creation request is received.
  * 
@@ -11,20 +13,28 @@ public class ServiceInstanceExistsException extends Exception {
 
 	private String serviceId;
 
+    /**
+     *  Whether this exception was thrown because the provision request would create an identical instance,
+     *  we want te return information about the service instance.
+     */
+    private ServiceInstanceOperationResponse response;
+
 	/**
 	 * Whether this exception was thrown because the provision request would create an identical instance.
 	 */
 	private boolean identicalInstance;
 
 	public ServiceInstanceExistsException(String instanceId, String serviceId) {
-		this(instanceId, serviceId, false);
+		this(instanceId, serviceId, false, null);
 	}
 
-	public ServiceInstanceExistsException(String instanceId, String serviceId, boolean identicalInstance) {
+	public ServiceInstanceExistsException(String instanceId, String serviceId, boolean identicalInstance,
+                                          ServiceInstanceOperationResponse response) {
 		this.instanceId = instanceId;
 		this.serviceId = serviceId;
 		this.identicalInstance = identicalInstance;
-	}
+        this.response = response;
+    }
 
 	@Override
 	public String getMessage() {
@@ -39,4 +49,13 @@ public class ServiceInstanceExistsException extends Exception {
 	public boolean isIdenticalInstance() {
 		return identicalInstance;
 	}
+
+    /**
+     * Returns the ServiceInstanceOperationResponse, that displays the information of the Service Instance that would be
+     * identical with the provision request.
+     * @return the ServiceInstanceOperationResponse that was provided, when creating this exception.
+     */
+    public ServiceInstanceOperationResponse getResponse() {
+        return response;
+    }
 }

--- a/model/src/main/java/de/evoila/cf/broker/model/ServiceInstance.java
+++ b/model/src/main/java/de/evoila/cf/broker/model/ServiceInstance.java
@@ -183,7 +183,7 @@ public class ServiceInstance implements BaseEntity<String> {
 		return dashboardUrl;
 	}
 
-	private void setDashboardUrl(String dashboardUrl) {
+	public void setDashboardUrl(String dashboardUrl) {
 		this.dashboardUrl = dashboardUrl;
 	}
 


### PR DESCRIPTION
When the provision request would create an already existing and identical service instance, the service broker returns information about the already created one.