### PR TITLE
Fix/osb 1107 change delete binding code structure as for create binding

### DIFF
--- a/core/src/main/java/de/evoila/cf/broker/repository/JobRepository.java
+++ b/core/src/main/java/de/evoila/cf/broker/repository/JobRepository.java
@@ -26,4 +26,10 @@ public interface JobRepository {
 
 	void deleteJobProgress(String id);
 
+    /**
+     * Used to delete a JobProgress Object with an instance or binding ID.
+     *
+     * @param referenceId @param referenceId the id of the object that is being created. For ServiceInstances the instanceId, for bindings th bindingId
+     */
+	void deleteJobProgressByReferenceId(String referenceId);
 }

--- a/core/src/main/java/de/evoila/cf/broker/service/impl/AsyncBindingServiceImpl.java
+++ b/core/src/main/java/de/evoila/cf/broker/service/impl/AsyncBindingServiceImpl.java
@@ -54,14 +54,13 @@ public class AsyncBindingServiceImpl extends AsyncOperationServiceImpl implement
         JobProgress jobProgress = jobProgressService.startJob(jobProgressId, bindingId,
                 "Deleting binding..", JobProgress.UNBIND);
         try {
-            bindingServiceImpl.syncDeleteServiceInstanceBinding(bindingId, serviceInstance, plan);
+            bindingServiceImpl.deleteServiceInstanceBinding(bindingId, serviceInstance, plan);
 
         } catch (Exception e) {
             jobProgressService.failJob(jobProgress.getId(),
                     "Internal error during binding deletion, please contact our support.");
 
             log.error("Exception during binding deletion", e);
-            return;
         }
     }
 

--- a/core/src/main/java/de/evoila/cf/broker/service/impl/DeploymentServiceImpl.java
+++ b/core/src/main/java/de/evoila/cf/broker/service/impl/DeploymentServiceImpl.java
@@ -307,7 +307,7 @@ public class DeploymentServiceImpl implements DeploymentService {
         }
 
         serviceInstanceRepository.deleteServiceInstance(serviceInstance.getId());
-        jobRepository.deleteJobProgress(serviceInstance.getId());
+        jobRepository.deleteJobProgressByReferenceId(serviceInstance.getId());
     }
 
     public void updateInstanceInfo(ServiceInstance serviceInstance) {


### PR DESCRIPTION
- changes structure of deleting a binding to the same as creating one.
- fixes non deleting of job progress objects for instances and bindings.

BREAKING CHANGE
osb-persistance needs to merge this PR: https://github.com/evoila/osb-persistence/pull/9