### PR TITLE
fix(BaseController): Enfore UUIDs for provisions and bindings

### DIFF
--- a/core/src/main/java/de/evoila/cf/broker/controller/BaseController.java
+++ b/core/src/main/java/de/evoila/cf/broker/controller/BaseController.java
@@ -9,11 +9,13 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
+import org.springframework.validation.annotation.Validated;
 import org.springframework.web.bind.annotation.ExceptionHandler;
 
 /**
  * @author Johannes Hiemer, Marco Di Martino.
  **/
+@Validated
 public abstract class BaseController {
 
     private final Logger log = LoggerFactory.getLogger(BaseController.class);
@@ -23,7 +25,7 @@ public abstract class BaseController {
     }
 
     protected ResponseEntity processEmptyErrorResponse(HttpStatus status) {
-      return new ResponseEntity<>(EmptyRestResponse.BODY, status);
+        return new ResponseEntity<>(EmptyRestResponse.BODY, status);
     }
 
     protected ResponseEntity processErrorResponse(String message, HttpStatus status) {
@@ -33,6 +35,11 @@ public abstract class BaseController {
     protected ResponseEntity<ServiceBrokerErrorResponse> processErrorResponse(String error, String description, HttpStatus status) {
         log.debug("Handled following service broker error: " + error + " - " + description);
         return new ResponseEntity<>(new ServiceBrokerErrorResponse(error, description), status);
+    }
+
+    @ExceptionHandler({javax.validation.ValidationException.class})
+    public ResponseEntity handleException(javax.validation.ValidationException ex) {
+        return processErrorResponse(ex.getMessage(), HttpStatus.BAD_REQUEST);
     }
 
     @ExceptionHandler({ValidationException.class})

--- a/core/src/main/java/de/evoila/cf/broker/controller/core/ServiceInstanceBindingController.java
+++ b/core/src/main/java/de/evoila/cf/broker/controller/core/ServiceInstanceBindingController.java
@@ -7,6 +7,8 @@ import de.evoila.cf.broker.model.annotations.ApiVersion;
 import de.evoila.cf.broker.model.annotations.ResponseAdvice;
 import de.evoila.cf.broker.service.CatalogService;
 import de.evoila.cf.broker.service.impl.BindingServiceImpl;
+import de.evoila.cf.broker.util.ParameterValidator;
+import de.evoila.cf.broker.util.UuidUtils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.http.HttpStatus;
@@ -15,6 +17,7 @@ import org.springframework.stereotype.Controller;
 import org.springframework.web.bind.annotation.*;
 
 import javax.validation.Valid;
+import javax.validation.constraints.Pattern;
 
 /**
  * @author Marco Di Martino, Johannes Hiemer
@@ -25,7 +28,7 @@ public class ServiceInstanceBindingController extends BaseController {
 
     private final Logger log = LoggerFactory.getLogger(ServiceInstanceBindingController.class);
 
-    public static final String SERVICE_INSTANCE_BINDING_BASE_PATH = "/core/service_instances/{instanceId}/service_bindings";
+    private static final String SERVICE_INSTANCE_BINDING_BASE_PATH = "/core/service_instances/{instanceId}/service_bindings";
 
     private BindingServiceImpl bindingService;
 
@@ -39,13 +42,16 @@ public class ServiceInstanceBindingController extends BaseController {
     @ResponseAdvice
     @ApiVersion({ApiVersions.API_213, ApiVersions.API_214, ApiVersions.API_215})
     @PutMapping(value = "/{instanceId}/service_bindings/{bindingId}")
-    public ResponseEntity bindServiceInstance(@PathVariable("instanceId") String instanceId,
-                                              @PathVariable("bindingId") String bindingId,
-                                              @RequestHeader("X-Broker-API-Version") String apiHeader,
-                                              @RequestHeader(value = "X-Broker-API-Request-Identity", required = false) String requestIdentity,
-                                              @RequestHeader(value = "X-Broker-API-Originating-Identity", required = false) String originatingIdentity,
-                                              @RequestParam(value = "accepts_incomplete", required = false, defaultValue = "") Boolean acceptsIncomplete,
-                                              @Valid @RequestBody ServiceInstanceBindingRequest request)
+    public ResponseEntity bindServiceInstance(
+            @Pattern(regexp = UuidUtils.UUID_REGEX, message = UuidUtils.NOT_A_UUID_MESSAGE)
+            @PathVariable("instanceId") String instanceId,
+            @Pattern(regexp = UuidUtils.UUID_REGEX, message = UuidUtils.NOT_A_UUID_MESSAGE)
+            @PathVariable("bindingId") String bindingId,
+            @RequestHeader("X-Broker-API-Version") String apiHeader,
+            @RequestHeader(value = "X-Broker-API-Request-Identity", required = false) String requestIdentity,
+            @RequestHeader(value = "X-Broker-API-Originating-Identity", required = false) String originatingIdentity,
+            @RequestParam(value = "accepts_incomplete", required = false, defaultValue = "") Boolean acceptsIncomplete,
+            @Valid @RequestBody ServiceInstanceBindingRequest request)
             throws ServiceInstanceBindingExistsException,
             ServiceBrokerException, ServiceDefinitionDoesNotExistException,
             InvalidParametersException, AsyncRequiredException, PlatformException, UnsupportedOperationException {

--- a/core/src/main/java/de/evoila/cf/broker/controller/core/ServiceInstanceController.java
+++ b/core/src/main/java/de/evoila/cf/broker/controller/core/ServiceInstanceController.java
@@ -12,14 +12,21 @@ import de.evoila.cf.broker.model.catalog.plan.Plan;
 import de.evoila.cf.broker.repository.ServiceInstanceRepository;
 import de.evoila.cf.broker.service.CatalogService;
 import de.evoila.cf.broker.service.DeploymentService;
+import de.evoila.cf.broker.util.ParameterValidator;
 import de.evoila.cf.broker.util.ServiceInstanceUtils;
+import de.evoila.cf.broker.util.UuidUtils;
+import org.everit.json.schema.ValidationException;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
+import org.springframework.validation.annotation.Validated;
 import org.springframework.web.bind.annotation.*;
 
 import javax.validation.Valid;
+import javax.validation.constraints.Pattern;
+import javax.validation.constraints.Size;
+import java.util.UUID;
 
 /**
  * @author Johannes Hiemer, Christian Brinker, Marco Di Martino.
@@ -30,7 +37,7 @@ public class ServiceInstanceController extends BaseController {
 
     private final Logger log = LoggerFactory.getLogger(ServiceInstanceController.class);
 
-    public static final String SERVICE_INSTANCE_BASE_PATH = "/v2/service_instances";
+    private static final String SERVICE_INSTANCE_BASE_PATH = "/v2/service_instances";
 
     private DeploymentService deploymentService;
 
@@ -53,7 +60,8 @@ public class ServiceInstanceController extends BaseController {
     @ApiVersion({ApiVersions.API_213, ApiVersions.API_214, ApiVersions.API_215})
     @PutMapping(value = "/{serviceInstanceId}")
     public ResponseEntity<ServiceInstanceOperationResponse> create(
-            @PathVariable("serviceInstanceId") String serviceInstanceId,
+            @PathVariable("serviceInstanceId")
+            @Pattern(regexp = UuidUtils.UUID_REGEX, message = UuidUtils.NOT_A_UUID_MESSAGE) String serviceInstanceId,
             @RequestParam(value = "accepts_incomplete", required = false) Boolean acceptsIncomplete,
             @Valid @RequestBody ServiceInstanceRequest request,
             @RequestHeader(value = "X-Broker-API-Originating-Identity", required = false) String originatingIdentity,
@@ -220,5 +228,4 @@ public class ServiceInstanceController extends BaseController {
 
         return new ResponseEntity<>(serviceInstanceResponse, HttpStatus.OK);
     }
-
 }

--- a/core/src/main/java/de/evoila/cf/broker/util/UuidUtils.java
+++ b/core/src/main/java/de/evoila/cf/broker/util/UuidUtils.java
@@ -1,8 +1,10 @@
 package de.evoila.cf.broker.util;
 
-import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
+/**
+ * author Johannes Strauß
+ */
 public class UuidUtils {
 
     public static final String UUID_REGEX = "^[0-9A-Fa-f]{8}-[0-9A-Fa-f]{4}-[0-9A-Fa-f]{4}-[0-9A-Fa-f]{4}-[0-9A-Fa-f]{12}$";

--- a/core/src/main/java/de/evoila/cf/broker/util/UuidUtils.java
+++ b/core/src/main/java/de/evoila/cf/broker/util/UuidUtils.java
@@ -1,5 +1,8 @@
 package de.evoila.cf.broker.util;
 
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
 public class UuidUtils {
 
     public static final String UUID_REGEX = "^[0-9A-Fa-f]{8}-[0-9A-Fa-f]{4}-[0-9A-Fa-f]{4}-[0-9A-Fa-f]{4}-[0-9A-Fa-f]{12}$";
@@ -7,4 +10,7 @@ public class UuidUtils {
     public static final String NOT_A_UUID_MESSAGE = "The ServiceInstanceID is not a valid UUID. Please only use valid UUIDs," +
             " too avoid unexpected errors.";
 
+    public static boolean isValidUUID(String uuid) {
+        return uuid != null && Pattern.matches(UUID_REGEX, uuid);
+    }
 }

--- a/core/src/main/java/de/evoila/cf/broker/util/UuidUtils.java
+++ b/core/src/main/java/de/evoila/cf/broker/util/UuidUtils.java
@@ -1,0 +1,10 @@
+package de.evoila.cf.broker.util;
+
+public class UuidUtils {
+
+    public static final String UUID_REGEX = "^[0-9A-Fa-f]{8}-[0-9A-Fa-f]{4}-[0-9A-Fa-f]{4}-[0-9A-Fa-f]{4}-[0-9A-Fa-f]{12}$";
+
+    public static final String NOT_A_UUID_MESSAGE = "The ServiceInstanceID is not a valid UUID. Please only use valid UUIDs," +
+            " too avoid unexpected errors.";
+
+}


### PR DESCRIPTION
Our Service Brokers don't respond well to non UUID instance and binding ids.
Therefore we should enforce UUIDs to avoid unnecessary errors.